### PR TITLE
WIP :Feature/expose http headers

### DIFF
--- a/Runtime/Scripts/GltFast.cs
+++ b/Runtime/Scripts/GltFast.cs
@@ -92,6 +92,7 @@ namespace GLTFast {
         IMaterialGenerator materialGenerator;
         IDeferAgent deferAgent;
 
+        public UnityAction<UnityWebRequest> onSettingRequest;
         public UnityAction<bool> onLoadComplete;
 
 #region VolatileData
@@ -150,7 +151,7 @@ namespace GLTFast {
             materialGenerator = new DefaultMaterialGenerator();
         }
 
-        public void Load( string url, IDeferAgent deferAgent=null ) {
+        public void Load( string url, IDeferAgent deferAgent=null, bool forceBinary = false) {
             bool gltfBinary = false;
             // quick glTF-binary check
             gltfBinary = url.EndsWith(GLB_EXT,StringComparison.OrdinalIgnoreCase);
@@ -160,11 +161,12 @@ namespace GLTFast {
                 gltfBinary = getIndex>=0 && url.Substring(getIndex-GLB_EXT.Length,GLB_EXT.Length).Equals(GLB_EXT,StringComparison.OrdinalIgnoreCase);
             }
             var da = deferAgent ?? monoBehaviour.gameObject.AddComponent<TimeBudgetPerFrameDeferAgent>();
-            monoBehaviour.StartCoroutine(LoadRoutine(url,gltfBinary,da));
+            monoBehaviour.StartCoroutine(LoadRoutine(url,forceBinary || gltfBinary,da));
         }
 
         IEnumerator LoadRoutine( string url, bool gltfBinary, IDeferAgent deferAgent ) {
             UnityWebRequest www = UnityWebRequest.Get(url);
+            onSettingRequest?.Invoke(www);
             yield return www.SendWebRequest();
      
             if(www.isNetworkError || www.isHttpError) {

--- a/Runtime/Scripts/GltfAsset.cs
+++ b/Runtime/Scripts/GltfAsset.cs
@@ -63,7 +63,10 @@ namespace GLTFast
         {
             var initialSize = _headers == null ? 0 : _headers.Length;
             var httpHeaders = new HttpHeaders[initialSize +1];
-            Array.Copy(_headers, httpHeaders, initialSize);
+            if(_headers != null)
+            {
+                Array.Copy(_headers, httpHeaders, initialSize);
+            }
             httpHeaders[initialSize] = new HttpHeaders() {
                 Key = key,
                 Value = value

--- a/Runtime/Scripts/GltfAsset.cs
+++ b/Runtime/Scripts/GltfAsset.cs
@@ -71,6 +71,15 @@ namespace GLTFast
             _headers = httpHeaders;
         }
 
+        /// <summary>
+        /// If you need to force loading binary in script
+        /// </summary>
+        /// <param name="force"></param>
+        public void SetForceBinary(bool force)
+        {
+            _forceBinary = force;   
+        }
+
         void Start()
         {
             if (loadOnStartup && !string.IsNullOrEmpty(url))

--- a/Runtime/Scripts/GltfAsset.cs
+++ b/Runtime/Scripts/GltfAsset.cs
@@ -54,6 +54,23 @@ namespace GLTFast
             Load(deferAgent);
         }
 
+        /// <summary>
+        /// Allow to set http header with scripts. Call this method before loading the asset
+        /// </summary>
+        /// <param name="key">Http header key</param>
+        /// <param name="value">Http header value</param>
+        public void AddHttpHeader(string key, string value)
+        {
+            var initialSize = _headers == null ? 0 : _headers.Length;
+            var httpHeaders = new HttpHeaders[initialSize +1];
+            Array.Copy(_headers, httpHeaders, initialSize);
+            httpHeaders[initialSize] = new HttpHeaders() {
+                Key = key,
+                Value = value
+            };
+            _headers = httpHeaders;
+        }
+
         void Start()
         {
             if (loadOnStartup && !string.IsNullOrEmpty(url))


### PR DESCRIPTION
Has spoken in [issue 69](https://github.com/atteneder/glTFast/issues/69) here is a small PR to have the possibility to set http headers. User can set them in the editor in the Gltf Asset component.
Then those a set with the trigger of an event when request is about to be sent.

I also had to allow the user to force binary format as our server doesn't have the name of the file in the url. It shouldn't break anything.