### PR TITLE
Add contentType and magic checks to gltf-binary determination

### DIFF
--- a/Runtime/Scripts/DefaultDownloadProvider.cs
+++ b/Runtime/Scripts/DefaultDownloadProvider.cs
@@ -28,6 +28,9 @@ namespace GLTFast.Loading {
     }
 
     public class AwaitableDownload : IDownload {
+        const string GLB_MIME = "model/gltf-binary";
+        const string GLTF_MIME = "model/gltf+json";
+
         protected UnityWebRequest request;
         protected UnityWebRequestAsyncOperation asynOperation;
 
@@ -56,7 +59,21 @@ namespace GLTFast.Loading {
         public string error { get { return request.error; } }
         public byte[] data { get { return request.downloadHandler.data; } }
         public string text { get { return request.downloadHandler.text; } }
-        public string contentType { get { return !success ? null : request.GetResponseHeader("ContentType"); } }
+        public bool? isBinary
+        {
+            get
+            {
+                if (success)
+                {
+                    string contentType = request.GetResponseHeader("ContentType");
+                    if (contentType == GLB_MIME)
+                        return true;
+                    if (contentType == GLTF_MIME)
+                        return false;
+                }
+                return null;
+            }
+        }
     }
 
     public class AwaitableTextureDownload : AwaitableDownload, ITextureDownload {

--- a/Runtime/Scripts/DefaultDownloadProvider.cs
+++ b/Runtime/Scripts/DefaultDownloadProvider.cs
@@ -56,6 +56,7 @@ namespace GLTFast.Loading {
         public string error { get { return request.error; } }
         public byte[] data { get { return request.downloadHandler.data; } }
         public string text { get { return request.downloadHandler.text; } }
+        public string contentType { get { return !success ? null : request.GetResponseHeader("ContentType"); } }
     }
 
     public class AwaitableTextureDownload : AwaitableDownload, ITextureDownload {

--- a/Runtime/Scripts/IDownload.cs
+++ b/Runtime/Scripts/IDownload.cs
@@ -28,6 +28,7 @@ namespace GLTFast.Loading {
         string error {get;}
         byte[] data { get; }
         string text { get; }
+        string contentType { get; }
     }
 
     public interface ITextureDownload : IDownload {

--- a/Runtime/Scripts/IDownload.cs
+++ b/Runtime/Scripts/IDownload.cs
@@ -28,7 +28,7 @@ namespace GLTFast.Loading {
         string error {get;}
         byte[] data { get; }
         string text { get; }
-        string contentType { get; }
+        bool? isBinary { get; }
     }
 
     public interface ITextureDownload : IDownload {


### PR DESCRIPTION
Hey @atteneder 
This PR is intended to add some further checks to determining whether a downloaded file is a gltf or glb.

It adds the contentType field to IDownload and checks it against `model/gltf-binary` and also checks for the glb magic as a last resort (as it's reasonable to expect that the content type may just be `application/octet-stream` if the server has not configured this).