### PR TITLE
Add ShaderGUI to support blend mode configurations

### DIFF
--- a/Editor.meta
+++ b/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 69598450d552f5f44b191743ba3fae43
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/GLTFastShaderGUI.cs
+++ b/Editor/GLTFastShaderGUI.cs
@@ -1,0 +1,71 @@
+﻿using UnityEditor;
+using UnityEngine;
+using static GLTFast.Materials.StandardShaderHelper;
+
+namespace GLTFast.Editor
+{
+    public class GLTFastShaderGUI : ShaderGUI
+    {
+        /// <summary>
+        /// Subset of <see cref="StandardShaderMode"/> as not all configurations are supported
+        /// </summary>
+        public enum BlendModeOption
+        {
+            Opaque = StandardShaderMode.Opaque,
+            Cutout = StandardShaderMode.Cutout,
+            Transparent = StandardShaderMode.Transparent,
+        }
+
+        public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] properties)
+        {
+            if (materialEditor.target is Material material)
+            {
+                string current = material.GetTag("RenderType", false);
+                BlendModeOption currentBlendMode = BlendModeOption.Opaque;
+
+                switch (current)
+                {
+                    case "":
+                    case "Opaque":
+                        currentBlendMode = BlendModeOption.Opaque;
+                        break;
+
+                    case "TransparentCutout":
+                        currentBlendMode = BlendModeOption.Cutout;
+                        break;
+                    case "Transparent":
+                        currentBlendMode = BlendModeOption.Transparent;
+                        break;
+
+                }
+                GUILayout.BeginHorizontal();
+                GUILayout.Label("Blend Mode");
+                BlendModeOption blend = (BlendModeOption)EditorGUILayout.EnumPopup(currentBlendMode);
+                GUILayout.EndHorizontal();
+
+                if (blend != currentBlendMode)
+                {
+                    ConfigureBlendMode(material, blend);
+                }
+            }
+
+            base.OnGUI(materialEditor, properties);
+        }
+
+        public static void ConfigureBlendMode(Material material, BlendModeOption mode)
+        {
+            switch (mode)
+            {
+                case BlendModeOption.Opaque:
+                    SetOpaqueMode(material);
+                    break;
+                case BlendModeOption.Cutout:
+                    SetAlphaModeMask(material, material.GetFloat(cutoffPropId));
+                    break;
+                case BlendModeOption.Transparent:
+                    SetAlphaModeBlend(material);
+                    break;
+            }
+        }
+    }
+}

--- a/Editor/GLTFastShaderGUI.cs.meta
+++ b/Editor/GLTFastShaderGUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8262fb96f3f02c3418d53dfe137bd6c2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/glTFastEditor.asmdef
+++ b/Editor/glTFastEditor.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "glTFastEditor",
+    "references": [
+        "GUID:a42927d1d4a3b4cda9b076a7adecb9cc",
+        "GUID:339cc51f8f5f946a99be775bcfa83f2e"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Editor/glTFastEditor.asmdef.meta
+++ b/Editor/glTFastEditor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 76676817d91ba4f44b4aa7df71867256
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/StandardShaderHelper.cs
+++ b/Runtime/Scripts/StandardShaderHelper.cs
@@ -57,8 +57,9 @@ namespace GLTFast.Materials {
         // public static int glossMapScaleId = Shader.PropertyToID("_GlossMapScale");
         public static int cullModePropId = Shader.PropertyToID("_CullMode");
 
-        public static void SetAlphaModeMask( UnityEngine.Material material,Schema.Material gltfMaterial) {
-			material.SetFloat(modePropId, (int)StandardShaderMode.Cutout);
+        public static void SetAlphaModeMask(UnityEngine.Material material, float alphaCutoff)
+        {
+            material.SetFloat(modePropId, (int)StandardShaderMode.Cutout);
             material.SetOverrideTag("RenderType", "TransparentCutout");
             material.SetInt(srcBlendPropId, (int)UnityEngine.Rendering.BlendMode.One);
             material.SetInt(dstBlendPropId, (int)UnityEngine.Rendering.BlendMode.Zero);
@@ -67,7 +68,12 @@ namespace GLTFast.Materials {
             material.DisableKeyword("_ALPHABLEND_ON");
             material.DisableKeyword("_ALPHAPREMULTIPLY_ON");
             material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.AlphaTest;  //2450
-            material.SetFloat(cutoffPropId, gltfMaterial.alphaCutoff);
+            material.SetFloat(cutoffPropId, alphaCutoff);
+        }
+
+        public static void SetAlphaModeMask(UnityEngine.Material material, Schema.Material gltfMaterial)
+        {
+            SetAlphaModeMask(material, gltfMaterial.alphaCutoff);
         }
 
         public static void SetAlphaModeBlend( UnityEngine.Material material ) {

--- a/Runtime/Shader/glTFPbrMetallicRoughness.shader
+++ b/Runtime/Shader/glTFPbrMetallicRoughness.shader
@@ -451,4 +451,5 @@ Shader "glTF/PbrMetallicRoughness"
 
     FallBack "VertexLit"
     // CustomEditor "StandardShaderGUI"
+    CustomEditor "GLTFast.Editor.GLTFastShaderGUI"
 }

--- a/Runtime/Shader/glTFPbrSpecularGlossiness.shader
+++ b/Runtime/Shader/glTFPbrSpecularGlossiness.shader
@@ -427,4 +427,5 @@ Shader "glTF/PbrSpecularGlossiness"
 
     FallBack "VertexLit"
     // CustomEditor "StandardShaderGUI"
+    CustomEditor "GLTFast.Editor.GLTFastShaderGUI"
 }


### PR DESCRIPTION
This PR just adds a simple dropdown to select the blend modes in the editor. It should address #72. Based on the discussion in #73 it also excludes Fade as an option.

![shader_gui](https://user-images.githubusercontent.com/19278856/95430841-13fda100-0998-11eb-9251-cd5f67f64378.gif)

**Reasoning:**
Currently it's difficult to configure the selection of preloaded shaders (because the GUI doesn't allow us to configure transparent materials). This can result in unintentional shader stripping. The current solution of loading a "sample" GLTF and snapshoting the variants works, but adds an extra step (of finding/creating the sample outside of Unity). This approach means that we can just have a scene of all the sample material types and snapshot this instead, without the additional step.