### PR TITLE
null check the texture before applying (Allow models with broken texture linkes to load)

### DIFF
--- a/Runtime/Scripts/GltFast.cs
+++ b/Runtime/Scripts/GltFast.cs
@@ -575,7 +575,7 @@ namespace GLTFast {
                             images[dl.Key] = txt;
                         }
                     } else {
-                        Debug.LogError(www.error);
+                        Debug.LogWarning(www.error);
                     }
                 }
             }

--- a/Runtime/Scripts/GltFast.cs
+++ b/Runtime/Scripts/GltFast.cs
@@ -575,7 +575,7 @@ namespace GLTFast {
                             images[dl.Key] = txt;
                         }
                     } else {
-                        Debug.LogWarning(www.error);
+                        Debug.LogError(www.error);
                     }
                 }
             }

--- a/Runtime/Scripts/Schema/Sampler.cs
+++ b/Runtime/Scripts/Schema/Sampler.cs
@@ -122,6 +122,7 @@ namespace GLTFast.Schema
         }
 
         public void Apply(Texture2D image) {
+            if (image == null) return;
             image.wrapModeU = wrapU;
             image.wrapModeV = wrapV;
             image.filterMode = filterMode;


### PR DESCRIPTION
Dear @atteneder , since you were so quick last time, I was wondering:

Would it make sense to still load a model, even if parts of it's linked textures are missing?

I.e. send a warning instead of an error?

In case that the texture gets a 404 here:

```
HTTP/1.1 404 Not Found
UnityEngine.Debug:LogError (object)
GLTFast.GLTFast/<WaitForTextureDownloads>d__58:MoveNext () (at /Users/konrad/Source/glTFast/Runtime/Scripts/GltFast.cs:578)
UnityEngine.SetupCoroutine:InvokeMoveNext (System.Collections.IEnumerator,intptr) (at /Users/bokken/buildslave/unity/build/Runtime/Export/Scripting/Coroutines.cs:17)
```

Then in the  `Apply` method will break and the model can't be loaded. We have a large set of models where modelers sometimes set a material during the modelling procedures but the texture links to some local folder. Since we set the correct materials at runtime, this hasn't mattered before, but with `gltFast` the import breaks at the `Apply(Texture2D image)`.

With the proposed change I can import all our models into a Unity app.