### PR TITLE
Fix: Texture offset/tiling values getting lost when switching to other shaders

### DIFF
--- a/Runtime/Scripts/MaterialGenerator.cs
+++ b/Runtime/Scripts/MaterialGenerator.cs
@@ -48,6 +48,7 @@ namespace GLTFast.Materials {
         public static readonly int cutoffPropId = Shader.PropertyToID("_Cutoff");
         public static readonly int emissionColorPropId = Shader.PropertyToID("_EmissionColor");
         public static readonly int emissionMapPropId = Shader.PropertyToID("_EmissionMap");
+        public static readonly int mainTexPropId = Shader.PropertyToID("_MainTex");
         public static readonly int mainTexRotation = Shader.PropertyToID("_MainTexRotation");
         public static readonly int mainTexScaleTransform = Shader.PropertyToID("_MainTex_ST");
         public static readonly int metallicPropId = Shader.PropertyToID("_Metallic");
@@ -210,6 +211,8 @@ namespace GLTFast.Materials {
                 textureST.y = -textureST.y; // flip scale in Y
             }
             
+            material.SetTextureOffset(mainTexPropId, textureST.zw);
+            material.SetTextureScale(mainTexPropId, textureST.xy);
             material.SetVector(mainTexScaleTransform, textureST);
         }
         


### PR DESCRIPTION
This is already an improvement, but there are some open questions:
- not sure if the call to SetVector("_MainTex_ST" is still needed now
- for the ShaderGraphMaterialGenerator, the right texture to set these on would be _BaseMap_ST
  - I saw TrySetTextureTransform actually takes a propertyId but then ignores it, so that could be directly used; I _think_ the reason it isn't right now is that it's not trivial to also set Rotation?