### PR TITLE
Fix error when tryting to set texture offset/scale but material doesn't have _MainTex property.

### DIFF
--- a/Runtime/Scripts/MaterialGenerator.cs
+++ b/Runtime/Scripts/MaterialGenerator.cs
@@ -211,8 +211,12 @@ namespace GLTFast.Materials {
                 textureST.y = -textureST.y; // flip scale in Y
             }
             
-            material.SetTextureOffset(mainTexPropId, textureST.zw);
-            material.SetTextureScale(mainTexPropId, textureST.xy);
+            if(material.HasProperty(mainTexPropId)) {
+                material.SetTextureOffset(mainTexPropId, textureST.zw);
+                material.SetTextureScale(mainTexPropId, textureST.xy);
+            }
+            material.SetTextureOffset(propertyId, textureST.zw);
+            material.SetTextureScale(propertyId, textureST.xy);
             material.SetVector(mainTexScaleTransform, textureST);
         }
         


### PR DESCRIPTION
Instead, set the actual texture's transform values correctly so custom shaders can use that if needed / wanted.