### PR TITLE
fix: safely destroy if GltFast is run in edit mode

### DIFF
--- a/Runtime/Scripts/GltFast.cs
+++ b/Runtime/Scripts/GltFast.cs
@@ -1359,17 +1359,26 @@ namespace GLTFast {
             return txt;
         }
 
+        private void SafeDestroy(UnityEngine.Object obj) {
+            if (Application.isPlaying) {
+                UnityEngine.Object.Destroy(obj);
+            }
+            else {
+                UnityEngine.Object.DestroyImmediate(obj);
+            }
+        }
+        
         public void Destroy() {
             if(materials!=null) {
                 foreach( var material in materials ) {
-                    UnityEngine.Object.Destroy(material);
+                    SafeDestroy(material);
                 }
                 materials = null;
             }
 
             if(resources!=null) {
                 foreach( var resource in resources ) {
-                    UnityEngine.Object.Destroy(resource);
+                    SafeDestroy(resource);
                 }
                 resources = null;
             }


### PR DESCRIPTION
I'm experimenting with using glTFast at edit time (not in Play mode!) and that's going great (will probably do a PR in a while), and stumbled upon this mini issue of glTFast not checking if it's play mode or edit mode time for Destroy operations on generated materials and resources.

This PR fixes that by wrapping Destroy/DestroyImmediate and doing an Application.isPlaying check.