### PR TITLE
File format fix

### DIFF
--- a/Runtime/Scripts/GltFast.cs
+++ b/Runtime/Scripts/GltFast.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020-2021 Andreas Atteneder
+// Copyright 2020-2021 Andreas Atteneder
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -2193,8 +2193,9 @@ namespace GLTFast {
             }
         }
 
- ImageFormat GetImageFormatFromPath(string path) {
-            if(path.EndsWith(".png",StringComparison.OrdinalIgnoreCase) || path.IndexOf(".png", StringComparison.OrdinalIgnoreCase) >= 0) return ImageFormat.PNG;
+        ImageFormat GetImageFormatFromPath(string path) {
+            if(path.EndsWith(".png",StringComparison.OrdinalIgnoreCase)
+                || path.IndexOf(".png", StringComparison.OrdinalIgnoreCase) >= 0) return ImageFormat.PNG;
             if(path.EndsWith(".jpg",StringComparison.OrdinalIgnoreCase) 
                 || path.EndsWith(".jpeg",StringComparison.OrdinalIgnoreCase) || path.IndexOf(".jpeg", StringComparison.OrdinalIgnoreCase) >= 0
                 || path.IndexOf(".jpg", StringComparison.OrdinalIgnoreCase) >= 0) return ImageFormat.Jpeg;

--- a/Runtime/Scripts/GltFast.cs
+++ b/Runtime/Scripts/GltFast.cs
@@ -2204,7 +2204,6 @@ namespace GLTFast {
                 || path.IndexOf(".jpeg", StringComparison.OrdinalIgnoreCase) >= 0) return ImageFormat.Jpeg;
             if(path.IndexOf(".ktx", StringComparison.OrdinalIgnoreCase) >= 0
                 || path.IndexOf(".ktx2", StringComparison.OrdinalIgnoreCase) >= 0) return ImageFormat.KTX;
-            
             return ImageFormat.Unknown;
         }
 

--- a/Runtime/Scripts/GltFast.cs
+++ b/Runtime/Scripts/GltFast.cs
@@ -2193,12 +2193,15 @@ namespace GLTFast {
             }
         }
 
-        ImageFormat GetImageFormatFromPath(string path) {
-            if(path.EndsWith(".png",StringComparison.OrdinalIgnoreCase)) return ImageFormat.PNG;
-            if(path.EndsWith(".jpg",StringComparison.OrdinalIgnoreCase)
-                || path.EndsWith(".jpeg",StringComparison.OrdinalIgnoreCase)) return ImageFormat.Jpeg;
+ ImageFormat GetImageFormatFromPath(string path) {
+            if(path.EndsWith(".png",StringComparison.OrdinalIgnoreCase) || path.IndexOf(".png", StringComparison.OrdinalIgnoreCase) >= 0) return ImageFormat.PNG;
+            if(path.EndsWith(".jpg",StringComparison.OrdinalIgnoreCase) 
+                || path.EndsWith(".jpeg",StringComparison.OrdinalIgnoreCase) || path.IndexOf(".jpeg", StringComparison.OrdinalIgnoreCase) >= 0
+                || path.IndexOf(".jpg", StringComparison.OrdinalIgnoreCase) >= 0) return ImageFormat.Jpeg;
             if(path.EndsWith(".ktx",StringComparison.OrdinalIgnoreCase)
-                || path.EndsWith(".ktx2",StringComparison.OrdinalIgnoreCase)) return ImageFormat.KTX;
+                || path.EndsWith(".ktx2",StringComparison.OrdinalIgnoreCase)
+                || path.IndexOf(".ktx", StringComparison.OrdinalIgnoreCase) >= 0
+                || path.IndexOf(".ktx2", StringComparison.OrdinalIgnoreCase) >= 0) return ImageFormat.KTX;
             return ImageFormat.Unknown;
         }
 

--- a/Runtime/Scripts/GltFast.cs
+++ b/Runtime/Scripts/GltFast.cs
@@ -2194,15 +2194,17 @@ namespace GLTFast {
         }
 
         ImageFormat GetImageFormatFromPath(string path) {
-            if(path.EndsWith(".png",StringComparison.OrdinalIgnoreCase)
-                || path.IndexOf(".png", StringComparison.OrdinalIgnoreCase) >= 0) return ImageFormat.PNG;
+            if(path.EndsWith(".png",StringComparison.OrdinalIgnoreCase)) return ImageFormat.PNG;
             if(path.EndsWith(".jpg",StringComparison.OrdinalIgnoreCase) 
-                || path.EndsWith(".jpeg",StringComparison.OrdinalIgnoreCase) || path.IndexOf(".jpeg", StringComparison.OrdinalIgnoreCase) >= 0
-                || path.IndexOf(".jpg", StringComparison.OrdinalIgnoreCase) >= 0) return ImageFormat.Jpeg;
+                || path.EndsWith(".jpeg",StringComparison.OrdinalIgnoreCase)) return ImageFormat.Jpeg;
             if(path.EndsWith(".ktx",StringComparison.OrdinalIgnoreCase)
-                || path.EndsWith(".ktx2",StringComparison.OrdinalIgnoreCase)
-                || path.IndexOf(".ktx", StringComparison.OrdinalIgnoreCase) >= 0
+                || path.EndsWith(".ktx2",StringComparison.OrdinalIgnoreCase)) return ImageFormat.KTX;
+            if(path.IndexOf(".png", StringComparison.OrdinalIgnoreCase) >= 0) return ImageFormat.PNG;
+            if(path.IndexOf(".jpg", StringComparison.OrdinalIgnoreCase) >= 0
+                || path.IndexOf(".jpeg", StringComparison.OrdinalIgnoreCase) >= 0) return ImageFormat.Jpeg;
+            if(path.IndexOf(".ktx", StringComparison.OrdinalIgnoreCase) >= 0
                 || path.IndexOf(".ktx2", StringComparison.OrdinalIgnoreCase) >= 0) return ImageFormat.KTX;
+            
             return ImageFormat.Unknown;
         }
 

--- a/Runtime/Scripts/GltFast.cs
+++ b/Runtime/Scripts/GltFast.cs
@@ -2194,16 +2194,14 @@ namespace GLTFast {
         }
 
         ImageFormat GetImageFormatFromPath(string path) {
-            if(path.EndsWith(".png",StringComparison.OrdinalIgnoreCase)) return ImageFormat.PNG;
-            if(path.EndsWith(".jpg",StringComparison.OrdinalIgnoreCase) 
-                || path.EndsWith(".jpeg",StringComparison.OrdinalIgnoreCase)) return ImageFormat.Jpeg;
-            if(path.EndsWith(".ktx",StringComparison.OrdinalIgnoreCase)
-                || path.EndsWith(".ktx2",StringComparison.OrdinalIgnoreCase)) return ImageFormat.KTX;
-            if(path.IndexOf(".png", StringComparison.OrdinalIgnoreCase) >= 0) return ImageFormat.PNG;
-            if(path.IndexOf(".jpg", StringComparison.OrdinalIgnoreCase) >= 0
-                || path.IndexOf(".jpeg", StringComparison.OrdinalIgnoreCase) >= 0) return ImageFormat.Jpeg;
-            if(path.IndexOf(".ktx", StringComparison.OrdinalIgnoreCase) >= 0
-                || path.IndexOf(".ktx2", StringComparison.OrdinalIgnoreCase) >= 0) return ImageFormat.KTX;
+            var queryStartIndex = path.LastIndexOf('?'); // Get start of query string.
+            if (queryStartIndex == -1) queryStartIndex = path.Length; // if no query exists string, set to end of the string.
+            var formatStartIndex = path.LastIndexOf('.', queryStartIndex); // we assume that the first period before the query string is the file format period.
+            if (formatStartIndex == -1) return ImageFormat.Unknown; // if we can't find a period, we don't know the file format.
+            var pathFormat = path.Substring(formatStartIndex, queryStartIndex - formatStartIndex); // extract the file ending
+            if (pathFormat.Equals(".png", StringComparison.OrdinalIgnoreCase)) return ImageFormat.PNG;
+            if (pathFormat.Equals(".jpg", StringComparison.OrdinalIgnoreCase) || pathFormat.Equals(".jpeg", StringComparison.OrdinalIgnoreCase)) return ImageFormat.Jpeg;
+            if (pathFormat.Equals(".ktx", StringComparison.OrdinalIgnoreCase) || pathFormat.Equals(".ktx2", StringComparison.OrdinalIgnoreCase)) return ImageFormat.KTX;
             return ImageFormat.Unknown;
         }
 


### PR DESCRIPTION
If a GLTF had URL query strings as part of its image URLs it GLTFast.cs would not recognize the file format. This was causing problems for me since I was getting GLTFs from a CDN that auto-generated the GLTFs with things like texture version info in the query strings. I fixed this by adding a set of "contains" checks after the "ends with" checks in GLTFast.cs. I added them at the end so that they will only be used if it does not end with a file format since I suspect that this will still be far more common.  