### PR TITLE
Add a downloaded data check to the glTF format detection

### DIFF
--- a/Runtime/Scripts/GltFast.cs
+++ b/Runtime/Scripts/GltFast.cs
@@ -252,6 +252,9 @@ namespace GLTFast {
                 if (gltfBinary ?? false) {
                     success = await LoadGltfBinaryBuffer(download.data,url);
                 } else {
+                    if (gltfBinary == null) {
+                        Debug.LogWarning("Failed to detect the file format, falling back to .gltf");
+                    }
                     success = await LoadGltf(download.text,url);
                 }
                 if(success) await LoadContent();


### PR DESCRIPTION
I've spent some time debugging an issue with loading a .glb model because the link didn't have the .glb extension. It is fine when the link doesn't have an extension because it may be provided by a link shortener service, for example. The error I received was "ArgumentException: JSON parse error: Invalid value." - not quite what I expected to see when the URI was wrong.

I changed the UriHelper.IsGltfBinary() method by making an additional check of the first couple of characters from the downloaded data if the URI check failed, so that if the URI doesn't have an extension but the file is of the .glb or .gltf format, the format will be detected correctly.

I also added a warning message when the file format cannot be detected so that if the user receives the JSON parse error, they get a hint of what to look for.

- [x] Unit Tests
- [x] Documentation

I extended UriHelperTest.IsGltfBinaryTest() but not sure how it conforms to your performance monitoring, so let me know if it should be changed somehow.