### PR TITLE
Add: None + Mecanim animation clip import

### DIFF
--- a/Editor/GltfImporter.cs
+++ b/Editor/GltfImporter.cs
@@ -128,6 +128,24 @@ namespace GLTFast.Editor {
                         AddObjectToAsset(ctx, $"animations/{animationClip.name}", animationClip);
                     }
                 }
+
+                // TODO seems the states don't properly connect to the Animator here
+                // (would need to be saved as SubAssets of the AnimatorController)
+                // var animators = go.GetComponentsInChildren<Animator>();
+                // foreach (var animator in animators)
+                // {
+                //     var controller = animator.runtimeAnimatorController as UnityEditor.Animations.AnimatorController;
+                //     if (controller != null) {
+                //         AddObjectToAsset(ctx, $"animatorControllers/{animator.name}", controller);
+                //         foreach (var layer in controller.layers)
+                //         {
+                //             var stateMachine = layer.stateMachine;
+                //             stateMachine.hideFlags = HideFlags.HideInHierarchy;
+                //             if(stateMachine)
+                //                 AddObjectToAsset(ctx, $"animatorControllers/{animator.name}/{stateMachine.name}", stateMachine);
+                //         }
+                //     }
+                // }
                 
                 m_ImportedNames = null;
                 m_ImportedObjects = null;

--- a/Editor/Resources/GltfImporter.uxml
+++ b/Editor/Resources/GltfImporter.uxml
@@ -3,6 +3,7 @@
         <Style src="GltfImporter-style.uss" />
         <ui:Label text="glTF Import Settings" class="h1" />
         <uie:EnumField label="Node Name Method" value="OriginalUnique" binding-path="importSettings.nodeNameMethod" type="GLTFast.ImportSettings+NameImportMethod, glTFast" />
+        <uie:EnumField label="Animation" value="Legacy" binding-path="importSettings.animationMethod" type="GLTFast.ImportSettings+AnimationMethod, glTFast" />
     </ui:VisualElement>
     <ui:VisualElement name="Dependencies" class="dependencies section">
         <Style src="GltfImporter-style.uss" />

--- a/Runtime/Scripts/GameObjectInstantiator.cs
+++ b/Runtime/Scripts/GameObjectInstantiator.cs
@@ -317,35 +317,40 @@ namespace GLTFast {
             if (animationClips != null) {
                 // we want to create an Animator for non-legacy clips, and an Animation component for legacy clips.
                 var isLegacyAnimation = animationClips.Length > 0 && animationClips[0].legacy;
-                
 // #if UNITY_EDITOR
 //                 // This variant creates a Mecanim Animator and AnimationController
 //                 // which does not work at runtime. It's kept for potential Editor import usage
-//
-//                 var animator = go.AddComponent<Animator>();
-//                 var controller = new AnimatorController();
-//                 
-//                 for (var index = 0; index < animationClips.Length; index++) {
-//                     var clip = animationClips[index];
-//                     controller.AddLayer(clip.name);
-//                     // controller.layers[index].defaultWeight = 1;
-//                     var stateMachine = controller.layers[index].stateMachine;
-//                     AnimatorState entryState = null;
-//                     var state = stateMachine.AddState(clip.name);
-//                     state.motion = clip;
-//                     var loopTransition = state.AddTransition(state);
-//                     loopTransition.hasExitTime = true;
-//                     loopTransition.duration = 0;
-//                     loopTransition.exitTime = 0;
-//                     entryState = state;
-//                     stateMachine.AddEntryTransition(entryState);
-//                 }
-//                 
-//                 animator.runtimeAnimatorController = controller;
-//                 
-//                 for (var index = 0; index < animationClips.Length; index++) {
-//                     controller.layers[index].blendingMode = AnimatorLayerBlendingMode.Additive;
-//                     animator.SetLayerWeight(index,1);
+//                 if(!isLegacyAnimation) {
+//                     var animator = go.AddComponent<Animator>();
+//                     var controller = new UnityEditor.Animations.AnimatorController();
+//                     controller.name = animator.name;
+//                     controller.AddLayer("Default");
+//                     controller.layers[0].defaultWeight = 1;
+//                     for (var index = 0; index < animationClips.Length; index++) {
+//                         var clip = animationClips[index];
+//                         // controller.AddLayer(clip.name);
+//                         // controller.layers[index].defaultWeight = 1;
+//                         var state = controller.AddMotion(clip, 0);
+//                         controller.AddParameter("Test", AnimatorControllerParameterType.Bool);
+//                         // var stateMachine = controller.layers[0].stateMachine;
+//                         // UnityEditor.Animations.AnimatorState entryState = null;
+//                         // var state = stateMachine.AddState(clip.name);
+//                         // state.motion = clip;
+//                         // var loopTransition = state.AddTransition(state);
+//                         // loopTransition.hasExitTime = true;
+//                         // loopTransition.duration = 0;
+//                         // loopTransition.exitTime = 0;
+//                         // entryState = state;
+//                         // stateMachine.AddEntryTransition(entryState);
+//                         // UnityEditor.Animations.AnimatorController.CreateAnimatorControllerAtPath
+//                     }
+//                     
+//                     animator.runtimeAnimatorController = controller;
+//                     
+//                     // for (var index = 0; index < animationClips.Length; index++) {
+//                     //     controller.layers[index].blendingMode = UnityEditor.Animations.AnimatorLayerBlendingMode.Additive;
+//                     //     animator.SetLayerWeight(index,1);
+//                     // }
 //                 }
 // #endif // UNITY_EDITOR
 

--- a/Runtime/Scripts/GameObjectInstantiator.cs
+++ b/Runtime/Scripts/GameObjectInstantiator.cs
@@ -315,6 +315,8 @@ namespace GLTFast {
 
 #if UNITY_ANIMATION
             if (animationClips != null) {
+                // we want to create an Animator for non-legacy clips, and an Animation component for legacy clips.
+                var isLegacyAnimation = animationClips.Length > 0 && animationClips[0].legacy;
                 
 // #if UNITY_EDITOR
 //                 // This variant creates a Mecanim Animator and AnimationController
@@ -347,16 +349,18 @@ namespace GLTFast {
 //                 }
 // #endif // UNITY_EDITOR
 
-                var animation = go.AddComponent<Animation>();
-                
-                for (var index = 0; index < animationClips.Length; index++) {
-                    var clip = animationClips[index];
-                    animation.AddClip(clip,clip.name);
-                    if (index < 1) {
-                        animation.clip = clip;
+                if(isLegacyAnimation) {
+                    var animation = go.AddComponent<Animation>();
+                    
+                    for (var index = 0; index < animationClips.Length; index++) {
+                        var clip = animationClips[index];
+                        animation.AddClip(clip,clip.name);
+                        if (index < 1) {
+                            animation.clip = clip;
+                        }
                     }
+                    animation.Play();
                 }
-                animation.Play();
             }
 #endif // UNITY_ANIMATION
         }

--- a/Runtime/Scripts/GltfImport.cs
+++ b/Runtime/Scripts/GltfImport.cs
@@ -1330,7 +1330,7 @@ namespace GLTFast {
             }
 
 #if UNITY_ANIMATION
-            if (gltfRoot.hasAnimation) {
+            if (gltfRoot.hasAnimation && settings.animationMethod != ImportSettings.AnimationMethod.None) {
                 
                 animationClips = new AnimationClip[gltfRoot.animations.Length];
                 for (var i = 0; i < gltfRoot.animations.Length; i++) {
@@ -1339,7 +1339,7 @@ namespace GLTFast {
                     animationClips[i].name = animation.name ?? $"Clip_{i}";
                     
                     // Legacy Animation requirement
-                    animationClips[i].legacy = true;
+                    animationClips[i].legacy = settings.animationMethod == ImportSettings.AnimationMethod.Legacy;
                     animationClips[i].wrapMode = WrapMode.Loop;
 
                     for (int j = 0; j < animation.channels.Length; j++) {

--- a/Runtime/Scripts/ImportSettings.cs
+++ b/Runtime/Scripts/ImportSettings.cs
@@ -39,6 +39,14 @@ namespace GLTFast {
             OriginalUnique
         }
 
+        public enum AnimationMethod
+        {
+            None,
+            Legacy,
+            Default
+        }
+
         public NameImportMethod nodeNameMethod = NameImportMethod.Original;
+        public AnimationMethod animationMethod = AnimationMethod.Legacy;
     }
 }

--- a/Runtime/Scripts/ImportSettings.cs
+++ b/Runtime/Scripts/ImportSettings.cs
@@ -43,7 +43,7 @@ namespace GLTFast {
         {
             None,
             Legacy,
-            Default
+            Mecanim
         }
 
         public NameImportMethod nodeNameMethod = NameImportMethod.Original;


### PR DESCRIPTION
When importing in the editor, it's not always desired to have legacy clips. This PR adds "None" and "Mecanim" as import options.

There's some commented code that attempts to import an AnimatorController + StateMachine as well, but it seems that isn't supported (?) from a ScriptedImporter as it would require adding StateMachine subassets to the AnimatorController subasset.
A workaround (not yet implemented here) would be to have an "Extract AnimatorController" button that creates and connects an AnimatorController as externalObjectMapping.