### PR TITLE
To allow usage without UNITY_ANIMATION add preprocessor makro around usages of animation

### DIFF
--- a/Editor/GltfImporter.cs
+++ b/Editor/GltfImporter.cs
@@ -125,12 +125,14 @@ namespace GLTFast.Editor {
                     }
                 }
                 
+#if UNITY_ANIMATION
                 var clips = m_Gltf.GetAnimationClips();
                 if (clips != null) {
                     foreach (var animationClip in clips) {
                         AddObjectToAsset(ctx, $"animations/{animationClip.name}", animationClip);
                     }
                 }
+#endif
                 
                 m_ImportedNames = null;
                 m_ImportedObjects = null;

--- a/Runtime/Scripts/GltfImport.cs
+++ b/Runtime/Scripts/GltfImport.cs
@@ -172,14 +172,12 @@ namespace GLTFast {
         /// https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#binary-buffer
         GlbBinChunk? glbBinChunk;
 
-#if UNITY_ANIMATION
         /// <summary>
         /// Unity's animation system addresses target GameObjects by hierarchical name.
         /// To make sure names are consistent and have no conflicts they are precalculated
         /// and stored in this array.
         /// </summary>
         string[] nodeNames;
-#endif
         
 #endregion VolatileData
 
@@ -1406,9 +1404,7 @@ namespace GLTFast {
         /// </summary>
         /// <returns>Array containing each node's parent node index (or -1 for root nodes)</returns>
         int[] CreateUniqueNames() {
-#if UNITY_ANIMATION
             nodeNames = new string[gltfRoot.nodes.Length];
-#endif
             var parentIndex = new int[gltfRoot.nodes.Length];
 
             for (var nodeIndex = 0; nodeIndex < gltfRoot.nodes.Length; nodeIndex++) {
@@ -1423,14 +1419,11 @@ namespace GLTFast {
                     childNames.Clear();
                     foreach (var child in node.children) {
                         parentIndex[child] = nodeIndex;
-#if UNITY_ANIMATION
                         nodeNames[child] = GetUniqueNodeName(gltfRoot, child, childNames);
-#endif
                     }
                 }
             }
 
-#if UNITY_ANIMATION
             for (int sceneId = 0; sceneId < gltfRoot.scenes.Length; sceneId++) {
                 childNames.Clear();
                 var scene = gltfRoot.scenes[sceneId];
@@ -1440,7 +1433,6 @@ namespace GLTFast {
                     }
                 }
             }
-#endif
 
             return parentIndex;
         }
@@ -1556,12 +1548,7 @@ namespace GLTFast {
                 
                 var node = gltfRoot.nodes[nodeIndex];
                 
-                var goName = 
-#if UNITY_ANIMATION
-                    nodeNames==null ? node.name : nodeNames[nodeIndex];
-#else
-                    node.name;
-#endif
+                var goName = nodeNames==null ? node.name : nodeNames[nodeIndex];
 
                 if(node.mesh>=0) {
                     var end = meshPrimitiveIndex[node.mesh+1];

--- a/Runtime/Scripts/GltfImport.cs
+++ b/Runtime/Scripts/GltfImport.cs
@@ -2042,7 +2042,6 @@ namespace GLTFast {
                         accessorData[i] = ads;
                         break;
                     }
-#if UNITY_ANIMATION
                     case GLTFAccessorAttributeType.VEC3 when (accessorUsage[i]&AccessorUsage.Translation)!=0:
                     {
                         var ads = new AccessorNativeData<Vector3>();
@@ -2067,6 +2066,7 @@ namespace GLTFast {
                         accessorData[i] = ads;
                         break;
                     }
+#if UNITY_ANIMATION
                     case GLTFAccessorAttributeType.SCALAR when accessorUsage[i]==AccessorUsage.AnimationTimes:
                     {
                         // JobHandle? jh;
@@ -2421,7 +2421,6 @@ namespace GLTFast {
             Profiler.EndSample();
         }
 
-#if UNITY_ANIMATION
         unsafe void GetVector3Job(Root gltf, int accessorIndex, out NativeArray<Vector3> vectors, out JobHandle? jobHandle, bool flip) {
             Profiler.BeginSample("GetVector3Job");
             var accessor = gltf.accessors[accessorIndex];
@@ -2524,6 +2523,7 @@ namespace GLTFast {
             Profiler.EndSample();
         }
         
+#if UNITY_ANIMATION
         void GetAnimationTimes(Root gltf, int accessorIndex, out NativeArray<float>? times) {
             // TODO: For long animations with lots of times, threading this just like everything else maybe makes sense.
             Profiler.BeginSample("GetAnimationTimes");

--- a/Runtime/Scripts/GltfImport.cs
+++ b/Runtime/Scripts/GltfImport.cs
@@ -391,12 +391,14 @@ namespace GLTFast {
                 materials = null;
             }
             
+#if UNITY_ANIMATION
             if (animationClips != null) {
                 foreach( var clip in animationClips ) {
                     SafeDestroy(clip);
                 }
                 animationClips = null;
             }
+#endif
 
             if(textures!=null) {
                 foreach( var texture in textures ) {
@@ -1404,7 +1406,9 @@ namespace GLTFast {
         /// </summary>
         /// <returns>Array containing each node's parent node index (or -1 for root nodes)</returns>
         int[] CreateUniqueNames() {
+#if UNITY_ANIMATION
             nodeNames = new string[gltfRoot.nodes.Length];
+#endif
             var parentIndex = new int[gltfRoot.nodes.Length];
 
             for (var nodeIndex = 0; nodeIndex < gltfRoot.nodes.Length; nodeIndex++) {
@@ -1419,11 +1423,14 @@ namespace GLTFast {
                     childNames.Clear();
                     foreach (var child in node.children) {
                         parentIndex[child] = nodeIndex;
+#if UNITY_ANIMATION
                         nodeNames[child] = GetUniqueNodeName(gltfRoot, child, childNames);
+#endif
                     }
                 }
             }
 
+#if UNITY_ANIMATION
             for (int sceneId = 0; sceneId < gltfRoot.scenes.Length; sceneId++) {
                 childNames.Clear();
                 var scene = gltfRoot.scenes[sceneId];
@@ -1433,6 +1440,7 @@ namespace GLTFast {
                     }
                 }
             }
+#endif
 
             return parentIndex;
         }
@@ -2047,6 +2055,7 @@ namespace GLTFast {
                         accessorData[i] = ads;
                         break;
                     }
+#if UNITY_ANIMATION
                     case GLTFAccessorAttributeType.VEC3 when (accessorUsage[i]&AccessorUsage.Translation)!=0:
                     {
                         var ads = new AccessorNativeData<Vector3>();
@@ -2071,7 +2080,6 @@ namespace GLTFast {
                         accessorData[i] = ads;
                         break;
                     }
-#if UNITY_ANIMATION
                     case GLTFAccessorAttributeType.SCALAR when accessorUsage[i]==AccessorUsage.AnimationTimes:
                     {
                         // JobHandle? jh;


### PR DESCRIPTION
hey @atteneder !
So our WebGL viewer is using Gltf and I am currently trying to minimise the webgl-built file size.
The goal is for it to load faster on clients websites. 
After some [support by schubkraft here](https://forum.unity.com/threads/whats-the-issue-with-webgl-on-mobile-when-unity-forma-clearly-shows-its-possible.1126460/#post-7281148) he said that one thing that should help is removing built-in modules that are not needed in our app.

Since we're mostly a static viewer for 3D models (Plus changing of materials), we don't need Physics, Animation, terrain etc, so I wanted to remove all of those.
With the proposed changes our project compiles again, without the built in `com.unity.modules.animation` module :)