### PR TITLE
Fix: set _METALLICGLOSSMAP and _OCCLUSION keywords in material editor on texture import

### DIFF
--- a/Editor/BuiltInShaderGUI.cs
+++ b/Editor/BuiltInShaderGUI.cs
@@ -37,7 +37,7 @@ namespace GLTFast.Editor
         }
 
         private UvTransform? uvTransform;
-
+        
         public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] properties)
         {
             if (materialEditor.target is Material material)
@@ -86,6 +86,21 @@ namespace GLTFast.Editor
                 if (GUI.changed) {
                     EditorUtility.SetDirty(material);
                 }
+
+                void EnsureKeywordForMap(string textureProperty, string keyword)
+                {
+                    if (material.HasProperty(textureProperty))
+                    {
+                        if(material.GetTexture(textureProperty) && !material.IsKeywordEnabled(keyword))
+                            material.EnableKeyword(keyword);
+                        
+                        if(!material.GetTexture(textureProperty) && material.IsKeywordEnabled(keyword))
+                            material.DisableKeyword(keyword);
+                    }
+                }
+
+                EnsureKeywordForMap("_MetallicGlossMap", "_METALLICGLOSSMAP");
+                EnsureKeywordForMap("_OcclusionMap", "_OCCLUSION");
             }
 
             base.OnGUI(materialEditor, properties);


### PR DESCRIPTION
When importing materials with such textures these keywords should be set, as the standard shaders otherwise won't work properly. Might be necessary to additionally check if the shader supports any of these, but there's no good runtime way of checking that as far as I know, so I'd rather make the default shaders work out of the box.