### PR TITLE
Fix first value of curve

### DIFF
--- a/Runtime/Scripts/AnimationUtils.cs
+++ b/Runtime/Scripts/AnimationUtils.cs
@@ -280,7 +280,7 @@ namespace GLTFast {
                 }
                 default: { // LINEAR
                     var prevTime = times[0];
-                    var prevValue = values[0];
+                    var prevValue = values[times.Length * curveIndex];
                     var inTangent = 0f;
                     
                     for (var i = 1; i < times.Length; i++) {

--- a/Runtime/Scripts/AnimationUtils.cs
+++ b/Runtime/Scripts/AnimationUtils.cs
@@ -280,7 +280,7 @@ namespace GLTFast {
                 }
                 default: { // LINEAR
                     var prevTime = times[0];
-                    var prevValue = values[times.Length * curveIndex];
+                    var prevValue = values[curveIndex];
                     var inTangent = 0f;
                     
                     for (var i = 1; i < times.Length; i++) {


### PR DESCRIPTION
This PR avoid to get the wrong `var prevValue = values[0]` for all blendshape curve:
![Screenshot 2021-11-15 at 23 14 24](https://user-images.githubusercontent.com/63807677/141862329-74f5dbab-a469-4568-835b-9750e4cfad67.png)

instead of
![Screenshot 2021-11-15 at 23 15 14](https://user-images.githubusercontent.com/63807677/141862345-7959c8c9-3691-474e-8ae5-1125efb91573.png)

What do you think about it @atteneder ?