### PR TITLE
Fix shader mode selection for glTF MASK mode

### DIFF
--- a/Runtime/Scripts/Material/ShaderGraphMaterialGenerator.cs
+++ b/Runtime/Scripts/Material/ShaderGraphMaterialGenerator.cs
@@ -477,7 +477,7 @@ namespace GLTFast.Materials {
             if (gltfMaterial.doubleSided) feature |= MetallicShaderFeatures.DoubleSided;
 
             if (!sm.HasValue) {
-                sm = gltfMaterial.alphaModeEnum != AlphaMode.OPAQUE ? gltfMaterial.alphaModeEnum == AlphaMode.BLEND ? ShaderMode.Blend : ShaderMode.Opaque : ShaderMode.Opaque;
+                sm = gltfMaterial.alphaModeEnum == AlphaMode.BLEND ? ShaderMode.Blend : ShaderMode.Opaque;
             } 
             
             feature |= (MetallicShaderFeatures)sm;

--- a/Runtime/Scripts/Material/ShaderGraphMaterialGenerator.cs
+++ b/Runtime/Scripts/Material/ShaderGraphMaterialGenerator.cs
@@ -477,7 +477,7 @@ namespace GLTFast.Materials {
             if (gltfMaterial.doubleSided) feature |= MetallicShaderFeatures.DoubleSided;
 
             if (!sm.HasValue) {
-                sm = gltfMaterial.alphaModeEnum != AlphaMode.OPAQUE ? ShaderMode.Blend : ShaderMode.Opaque;
+                sm = gltfMaterial.alphaModeEnum != AlphaMode.OPAQUE ? gltfMaterial.alphaModeEnum == AlphaMode.BLEND ? ShaderMode.Blend : ShaderMode.Opaque : ShaderMode.Opaque;
             } 
             
             feature |= (MetallicShaderFeatures)sm;


### PR DESCRIPTION
This fixes the alpha coverage mode for glTF `MASK` mode. The `alphaCutoff` value is used correctly but the material generator assigns the blend shader which is wrong for `MASK` materials. Assigning the opaque shader is correct here. 

Can be tested with this model: [Alpha Blend Mode Test](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/AlphaBlendModeTest).