### PR TITLE
Made SetNodeName method overridable in GameObjectInstantiator class

### DIFF
--- a/Runtime/Scripts/GameObjectInstantiator.cs
+++ b/Runtime/Scripts/GameObjectInstantiator.cs
@@ -80,7 +80,7 @@ namespace GLTFast {
             nodes[nodeIndex].transform.SetParent(nodes[parentIndex].transform,false);
         }
 
-        public void SetNodeName(uint nodeIndex, string name) {
+        public virtual void SetNodeName(uint nodeIndex, string name) {
             nodes[nodeIndex].name = name ?? $"Node-{nodeIndex}";
         }
 


### PR DESCRIPTION
In order to make a custom implementation of the GameObjcetInstantiator class which allows to get the references of the different game objects instatntiated in the scene, we need to make the SetNodeName method virtual.

Other similar methods may be in need of overridability.