### PR TITLE
Do not create duplicate textures if samplers are equal.

### DIFF
--- a/Fighter jet.glb
+++ b/Fighter jet.glb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4fc9d5574ec12fab57fd19d8c27fcbe60ff8ab40d2c32a0eb38f51973092e8a1
+size 42185260

--- a/Fighter jet.glb
+++ b/Fighter jet.glb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4fc9d5574ec12fab57fd19d8c27fcbe60ff8ab40d2c32a0eb38f51973092e8a1
-size 42185260

--- a/Runtime/Scripts/GltfImport.cs
+++ b/Runtime/Scripts/GltfImport.cs
@@ -1170,30 +1170,6 @@ namespace GLTFast {
 
 #endif // MESHOPT
 
-        private struct SamplerKey : IEquatable<SamplerKey> {
-            private Sampler m_s;
-            public Sampler Sampler {
-                get { return m_s; }
-            }
-
-            public SamplerKey(Sampler sampler) {
-                m_s = sampler;
-            }
-
-            public override int GetHashCode() {
-                return (m_s.magFilter, m_s.minFilter, m_s.wrapS, m_s.wrapT).GetHashCode();
-            }
-
-            public bool Equals(SamplerKey other) {
-                return m_s.magFilter == other.m_s.magFilter &&
-                    m_s.minFilter == other.m_s.minFilter &&
-                    m_s.wrapS == other.m_s.wrapS &&
-                    m_s.wrapT == other.m_s.wrapT;
-            }
-
-            public override bool Equals(object obj) => obj is SamplerKey other && Equals(other);
-        }
-
         async Task<bool> Prepare() {
             if(gltfRoot.meshes!=null) {
                 meshPrimitiveIndex = new int[gltfRoot.meshes.Length+1];
@@ -1291,7 +1267,7 @@ namespace GLTFast {
                 {
                     var txt = gltfRoot.textures[textureIndex];
                     SamplerKey key;
-                    if(txt.sampler >= 0) {
+                    if(txt.sampler>=0) {
                         key = new SamplerKey(gltfRoot.samplers[txt.sampler]);
                     } else {
                         key = defaultKey;
@@ -1299,11 +1275,10 @@ namespace GLTFast {
 
                     var imageIndex = txt.GetImageIndex();
                     var img = images[imageIndex];
-                    if(imageVariants[imageIndex] == null) {
+                    if(imageVariants[imageIndex]==null) {
                         if(txt.sampler>=0) {
                             key.Sampler.Apply(img, settings.defaultMinFilterMode, settings.defaultMagFilterMode);
                         }
-
                         imageVariants[imageIndex] = new Dictionary<SamplerKey,Texture2D>();
                         imageVariants[imageIndex][key] = img;
                         textures[textureIndex] = img;
@@ -1311,13 +1286,13 @@ namespace GLTFast {
                         if (imageVariants[imageIndex].TryGetValue(key, out var imgVariant)) {
                             textures[textureIndex] = imgVariant;
                         } else {
-                            var newImg = UnityEngine.Object.Instantiate(img);
+                            var newImg = Texture2D.Instantiate(img);
                             resources.Add(newImg);
 #if DEBUG
                             newImg.name = string.Format("{0}_sampler{1}",img.name,txt.sampler);
                             logger?.Warning(LogCode.ImageMultipleSamplers,imageIndex.ToString());
 #endif
-                            if (txt.sampler >= 0) {
+                            if (txt.sampler>=0) {
                                 key.Sampler.Apply(newImg, settings.defaultMinFilterMode, settings.defaultMagFilterMode);
                             }
                             imageVariants[imageIndex][key] = newImg;

--- a/Runtime/Scripts/SamplerKey.cs
+++ b/Runtime/Scripts/SamplerKey.cs
@@ -1,0 +1,28 @@
+using System;
+using GLTFast.Schema;
+
+namespace GLTFast {
+    internal struct SamplerKey : IEquatable<SamplerKey> {
+        private Sampler m_s;
+        public Sampler Sampler {
+            get { return m_s; }
+        }
+
+        public SamplerKey(Sampler sampler) {
+            m_s = sampler;
+        }
+
+        public override int GetHashCode() {
+            return (m_s.magFilter, m_s.minFilter, m_s.wrapS, m_s.wrapT).GetHashCode();
+        }
+
+        public bool Equals(SamplerKey other) {
+            return m_s.magFilter == other.m_s.magFilter &&
+                m_s.minFilter == other.m_s.minFilter &&
+                m_s.wrapS == other.m_s.wrapS &&
+                m_s.wrapT == other.m_s.wrapT;
+        }
+
+        public override bool Equals(object obj) => obj is SamplerKey other && Equals(other);
+    }
+}

--- a/Runtime/Scripts/SamplerKey.cs.meta
+++ b/Runtime/Scripts/SamplerKey.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 81a4096ec93ed3346b0ab71bc8359274
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This fixes a bug where many duplicate textures were created, whereas there is no reason to create duplicates, since the samplers are equal.