### PR TITLE
Set PSIZE to 1 in VertexOutput

### DIFF
--- a/Runtime/Shader/Built-In/glTFIncludes/glTFUnityStandardCore.cginc
+++ b/Runtime/Shader/Built-In/glTFIncludes/glTFUnityStandardCore.cginc
@@ -423,6 +423,7 @@ struct VertexOutputForwardBase
     float4 eyeVec                         : TEXCOORD1;    // eyeVec.xyz | fogCoord
     float4 tangentToWorldAndPackedData[3] : TEXCOORD2;    // [3x3:tangentToWorld | 1x3:viewDirForParallax or worldPos]
     half4 ambientOrLightmapUV             : TEXCOORD5;    // SH or Lightmap UV
+    float pointSize                       : PSIZE;
     UNITY_LIGHTING_COORDS(6,7)
 
     // next ones would not fit into SM2.0 limits, but they are always for SM3.0+
@@ -508,6 +509,7 @@ VertexOutputForwardBase vertForwardBase (VertexInput v)
 
     UNITY_TRANSFER_FOG_COMBINED_WITH_EYE_VEC(o,o.pos);
     o.color = v.color;
+    o.pointSize = 1;
     return o;
 }
 
@@ -557,6 +559,7 @@ struct VertexOutputForwardAdd
     float4 eyeVec                       : TEXCOORD1;    // eyeVec.xyz | fogCoord
     float4 tangentToWorldAndLightDir[3] : TEXCOORD2;    // [3x3:tangentToWorld | 1x3:lightDir]
     float3 posWorld                     : TEXCOORD5;
+    float pointSize                     : PSIZE;
     UNITY_LIGHTING_COORDS(6, 7)
 
     // next ones would not fit into SM2.0 limits, but they are always for SM3.0+
@@ -635,6 +638,7 @@ VertexOutputForwardAdd vertForwardAdd (VertexInput v)
 
     UNITY_TRANSFER_FOG_COMBINED_WITH_EYE_VEC(o, o.pos);
     o.color = v.color;
+    o.pointSize = 1;
     return o;
 }
 
@@ -677,6 +681,7 @@ struct VertexOutputDeferred
         float3 posWorld                     : TEXCOORD6;
     #endif
     half4 color                             : COLOR;
+    float pointSize                         : PSIZE;
 
 #if defined(_OCCLUSION) || defined(_METALLICGLOSSMAP) || defined(_SPECGLOSSMAP)
     float4 texORM                       : TEXCOORD9;
@@ -761,6 +766,7 @@ VertexOutputDeferred vertDeferred (VertexInput v)
     #endif
 
     o.color = v.color;
+    o.pointSize = 1;
 
     return o;
 }

--- a/Runtime/Shader/Built-In/glTFIncludes/glTFUnityStandardCoreForwardSimple.cginc
+++ b/Runtime/Shader/Built-In/glTFIncludes/glTFUnityStandardCoreForwardSimple.cginc
@@ -58,6 +58,7 @@ struct VertexOutputBaseSimple
 #endif
 
     half4 color                         : COLOR;
+    float pointSize                     : PSIZE;
     UNITY_VERTEX_OUTPUT_STEREO
 };
 
@@ -142,6 +143,7 @@ VertexOutputBaseSimple vertForwardBaseSimple (VertexInput v)
     #if !GLOSSMAP
         o.eyeVec.w = saturate(_Glossiness + UNIFORM_REFLECTIVITY()); // grazing term
     #endif
+    o.pointSize = 1;
 
     UNITY_TRANSFER_FOG(o, o.pos);
     return o;
@@ -298,6 +300,7 @@ struct VertexOutputForwardAddSimple
     float2 texEmission                  : TEXCOORD8;
 #endif
     half4 color                         : COLOR;
+    float pointSize                     : PSIZE;
 
     UNITY_LIGHTING_COORDS(5, 6)
 
@@ -344,6 +347,7 @@ VertexOutputForwardAddSimple vertForwardAddSimple (VertexInput v)
             o.fogCoord.yzw = reflect(eyeVec, normalWorld);
         #endif
     #endif
+    o.pointSize = 1;
 
     UNITY_TRANSFER_FOG(o,o.pos);
     return o;


### PR DESCRIPTION
If the gltf model has Topology type Point, as gltfast shaders doesn't set or initialize any number to PSIZE, points are really big on iOS - Vulkan as below.
![points_01](https://user-images.githubusercontent.com/830808/150839186-a6225f09-2f1c-4e08-b5b9-0cc74f0fcecb.JPG)


This PR sets PSIZE to 1 by default so it will fix the point size like this.
![points_02](https://user-images.githubusercontent.com/830808/150839212-4bfa3443-f2b2-4599-9fe9-d46276218daa.JPG)


This is applied for FowardBase / ForwardAdd / ForwardSimple / Deferred passes of Built-in shaders.
