### PR TITLE
Made AddScene method overridable in GameObjectInstantiator class

### DIFF
--- a/Runtime/Scripts/GameObjectInstantiator.cs
+++ b/Runtime/Scripts/GameObjectInstantiator.cs
@@ -324,7 +324,7 @@ namespace GLTFast {
         //     }
         // }
 
-        public void AddScene(
+        public virtual void AddScene(
             string name,
             uint[] nodeIndices
 #if UNITY_ANIMATION


### PR DESCRIPTION
In order to rename the GameObject holding the different nodes with our custom instantiator.

Other similar methods may be in need of overridability.