### PR TITLE
Fix: Wrong File API used for reading bytes in EditorDownloadProvider

### DIFF
--- a/Editor/Scripts/EditorDownloadProvider.cs
+++ b/Editor/Scripts/EditorDownloadProvider.cs
@@ -58,7 +58,7 @@ namespace GLTFast.Editor {
     public class SyncFileLoader : IDownload {
         public SyncFileLoader(Uri url) {
             var path = url.OriginalString;
-            data = UnityEngine.Windows.File.ReadAllBytes(path);
+            data = File.ReadAllBytes(path);
         }
         
         public object Current => null;


### PR DESCRIPTION
Probably an autocomplete error. The UnityEngine.Windows.File API is only available for UWP build targets and shouldn't be used elsewhere.