### PR TITLE
Feat: allow for turning the ScriptedImporter of glTFast on or off via scripting defines

### DIFF
--- a/Editor/Scripts/GltfImporter.cs
+++ b/Editor/Scripts/GltfImporter.cs
@@ -15,6 +15,21 @@
 
 #if !GLTFAST_EDITOR_IMPORT_OFF
 
+// glTFast is on the path to being official, so it should have highest priority as importer by default
+// This ifdef is included for completeness.
+// Other glTF importers should specify this via AsmDef dependency, for example
+// `com.atteneder.gltfast@3.0.0: HAVE_GLTFAST` and then checking here `#if HAVE_GLTFAST`
+#if false 
+#define ANOTHER_IMPORTER_HAS_HIGHER_PRIORITY
+#endif
+
+#if !ANOTHER_IMPORTER_HAS_HIGHER_PRIORITY && !GLTFAST_FORCE_DEFAULT_IMPORTER_OFF
+#define ENABLE_DEFAULT_GLB_IMPORTER
+#endif
+#if GLTFAST_FORCE_DEFAULT_IMPORTER_ON
+#define ENABLE_DEFAULT_GLB_IMPORTER
+#endif
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -30,7 +45,11 @@ using Object = UnityEngine.Object;
 
 namespace GLTFast.Editor {
 
+#if ENABLE_DEFAULT_GLB_IMPORTER
     [ScriptedImporter(1,new [] {"gltf","glb"})] 
+#else
+    [ScriptedImporter(1, null, overrideExts: new[] { "gltf","glb" })]
+#endif
     public class GltfImporter : ScriptedImporter {
 
         [SerializeField]


### PR DESCRIPTION
This allows users to decide which glTF importer should have precedence.
glTFast is assumed to have the highest priority since its the closest to being"official" right now.

Other importers should properly check for glTFast existance (and potentially other package importer as well) and have lower priority. The pattern here also allows to explicitly define an order, for example these two together would turn on UnityGLTF as default importer:
`UNITYGLTF_FORCE_DEFAULT_IMPORTER_ON`
`GLTFAST_FORCE_DEFAULT_IMPORTER_OFF`

Here's the matching commit in UnityGLTF: https://github.com/prefrontalcortex/UnityGLTF/commit/51d92af70324b0be6397299155ca8efb7cd54df4

If this PR doesn't get in it's not that bad (by default should still work at least with UnityGltf / other known importers that respect glTFast being the default), it would just allow for explicit control.