### PR TITLE
Default to not exporting inactive objects

### DIFF
--- a/Editor/Scripts/MenuEntries.cs
+++ b/Editor/Scripts/MenuEntries.cs
@@ -111,7 +111,7 @@ namespace GLTFast.Editor {
             );
             if (!string.IsNullOrEmpty(path)) {
                 var settings = GetDefaultSettings(binary);
-                var goSettings = new GameObjectExportSettings { onlyActiveInHierarchy = false };
+                var goSettings = new GameObjectExportSettings();
                 var export = new GameObjectExport(settings, gameObjectExportSettings: goSettings, logger: new ConsoleLogger());
                 export.AddScene(gameObjects, name);
                 AsyncHelpers.RunSync(() => export.SaveToFileAndDispose(path));


### PR DESCRIPTION
Default to not exporting inactive objects when invoked from the menu.