### PR TITLE
Set `defaultDeferAgent` null in destructor

### DIFF
--- a/Runtime/Scripts/GltfImport.cs
+++ b/Runtime/Scripts/GltfImport.cs
@@ -265,6 +265,11 @@ namespace GLTFast {
             this.logger = logger;
         }
 
+        ~GltfImport()
+        {
+            defaultDeferAgent = null;
+        }
+
 #region Public
 
         /// <summary>


### PR DESCRIPTION
Potential fix for #165 

This PR sets the `defaultDeferAgent` to null in a new destructor inside `GltfImport`. Without doing this, there is a dangling reference to a `TimeBudgetPerFrameDeferAgent` stored on a GameObject in the previous scene, which does not persist across scene changes. Without this PR, you can observe that the `glTFast_DeferAgent` GameObject is not present in the scene heirarchy after the scene is reloaded.

Another potential fix would be to set the GameObject containing `TimeBudgetPerFrameDeferAgent` to not destroy on load. If that's preferred, I can switch this PR to perform that method instead.

This contribution is funded by [Envoke Demos](https://envoke-demos.com).