### PR TITLE
Fix: design-time import should use Mecanim by default and generate mipmaps

### DIFF
--- a/Editor/Scripts/GltfImporter.cs
+++ b/Editor/Scripts/GltfImporter.cs
@@ -101,7 +101,9 @@ namespace GLTFast.Editor {
                 // Design-time import specific changes to default settings
                 importSettings = new ImportSettings {
                     // Avoid naming conflicts by default
-                    nodeNameMethod = ImportSettings.NameImportMethod.OriginalUnique
+                    nodeNameMethod = ImportSettings.NameImportMethod.OriginalUnique,
+                    generateMipMaps = true,
+                    animationMethod = ImportSettings.AnimationMethod.Mecanim,
                 };
             }
             


### PR DESCRIPTION
Existing files won't be changed since the importer settings are serialized at first creation if they don't exist (good design choice!).
Legacy animation clips don't really make sense to import (can't be used in a number of places), and the additional time required to generate mipmaps isn't as much of a concern for design-time import.