### PR TITLE
Fix: legacy shadergraph had a wrong _BaseMap_ST type leading to import errors in 2021.2+

### DIFF
--- a/Runtime/Shader/Legacy/glTF-pbrSpecularGlossiness-Opaque-double.shadergraph
+++ b/Runtime/Shader/Legacy/glTF-pbrSpecularGlossiness-Opaque-double.shadergraph
@@ -26,7 +26,7 @@
         },
         {
             "typeInfo": {
-                "fullName": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty"
+                "fullName": "UnityEditor.ShaderGraph.Internal.Vector4ShaderProperty"
             },
             "JSONnodeData": "{\n    \"m_Guid\": {\n        \"m_GuidSerialized\": \"c88ceb4f-145c-4ab6-ba62-5c9f70d859d2\"\n    },\n    \"m_Name\": \"baseColorTexture_ST (1)\",\n    \"m_DefaultReferenceName\": \"Vector1_4282EC36\",\n    \"m_OverrideReferenceName\": \"_BaseMap_ST\",\n    \"m_GeneratePropertyBlock\": true,\n    \"m_Precision\": 0,\n    \"m_GPUInstanced\": false,\n    \"m_Hidden\": false,\n    \"m_Value\": 0.0,\n    \"m_FloatType\": 2,\n    \"m_RangeValues\": {\n        \"x\": 0.0,\n        \"y\": 1.0\n    }\n}"
         },


### PR DESCRIPTION
This PR simply fixes the type (was Vector1) to be Vector4.

Otherwise, these errors appear on import, presumably because of weird stuff going on with internal conversion between _MainTex and _BaseMap (but it was nonetheless a bug):

> Property _BaseMap_ST already exists in the property sheet with a different type: 3
UnityEditor.AssetImporters.ScriptedImporter:GenerateAssetData (UnityEditor.AssetImporters.AssetImportContext)