### PR TITLE
KTX upgrade with loading improvements

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Shader keyword `_UV_ROTATION` was replaced by `_TEXTURE_TRANSFORM`, which now controls tiling, offset and rotation all together
 - Animation is not played by default anymore (check the upgrade guide on how to restore this behavior; #339)
 - Instantiation is async now. This helps to ensure a stable frame rate when loading bigger glTF scenes (#205)
+- Sped up loading of external KTX textures by avoid making a redundant memory copy.
 ### Removed
 - Obsolete code
   - `GltfImport.Destroy` (was renamed to `GltfImport.Dispose`)

--- a/Runtime/Scripts/GltfImport.cs
+++ b/Runtime/Scripts/GltfImport.cs
@@ -17,6 +17,12 @@
 #define GLTFAST_THREADS
 #endif
 
+#if KTX_UNITY_2_2_OR_NEWER || (!UNITY_2021_2_OR_NEWER && KTX_UNITY_1_3_OR_NEWER)
+#define KTX
+#elif KTX_UNITY
+#warning You have to update KtxUnity to enable support for KTX textures in glTFast
+#endif
+
 // #define MEASURE_TIMINGS
 
 using System;
@@ -37,6 +43,9 @@ using Unity.Collections.LowLevel.Unsafe;
 using Unity.Mathematics;
 using Debug = UnityEngine.Debug;
 using Object = UnityEngine.Object;
+#if KTX
+using KtxUnity;
+#endif
 #if MESHOPT
 using Meshoptimizer;
 #endif
@@ -96,7 +105,7 @@ namespace GLTFast {
 #if DRACO_UNITY
             ExtensionName.DracoMeshCompression,
 #endif
-#if KTX_UNITY
+#if KTX
             ExtensionName.TextureBasisUniversal,
 #endif // KTX_UNITY
 #if MESHOPT
@@ -139,7 +148,7 @@ namespace GLTFast {
         GlbBinChunk[] binChunks;
 
         Dictionary<int,Task<IDownload>> downloadTasks;
-#if KTX_UNITY
+#if KTX
         Dictionary<int,Task<IDownload>> ktxDownloadTasks;
 #endif
         Dictionary<int,TextureDownloadBase> textureDownloadTasks;
@@ -157,7 +166,7 @@ namespace GLTFast {
         /// </summary>
         Dictionary<MeshPrimitive,List<MeshPrimitive>>[] meshPrimitiveCluster;
         List<ImageCreateContext> imageCreateContexts;
-#if KTX_UNITY
+#if KTX
         List<KtxLoadContextBase> ktxLoadContextsBuffer;
 #endif // KTX_UNITY
 
@@ -781,7 +790,7 @@ namespace GLTFast {
                 textureDownloadTasks.Clear();
             }
             
-#if KTX_UNITY
+#if KTX
             if (ktxDownloadTasks != null) {
                 success = success && await WaitForKtxDownloads();
                 ktxDownloadTasks.Clear();
@@ -945,7 +954,7 @@ namespace GLTFast {
                     }
                 }
 
-#if KTX_UNITY
+#if KTX
                 // Derive image type from texture extension
                 for (int i = 0; i < gltfRoot.textures.Length; i++) {
                     var texture = gltfRoot.textures[i];
@@ -1123,7 +1132,7 @@ namespace GLTFast {
         }
 
 
-#if KTX_UNITY
+#if KTX
         async Task<bool> WaitForKtxDownloads() {
             var tasks = new Task<bool>[ktxDownloadTasks.Count];
             var i = 0;
@@ -1138,18 +1147,21 @@ namespace GLTFast {
             return true;
         }
         
-        async Task<bool> ProcessKtxDownload(int index, Task<IDownload> downloadTask) {
+        async Task<bool> ProcessKtxDownload(int imageIndex, Task<IDownload> downloadTask) {
             var www = await downloadTask;
             if(www.success) {
-                var ktxContext = new KtxLoadContext(index,www.data);
-                var forceSampleLinear = imageGamma!=null && !imageGamma[ktxContext.imageIndex];
-                var textureResult = await ktxContext.LoadKtx(forceSampleLinear);
-                images[ktxContext.imageIndex] = textureResult.texture;
-                return true;
+                var ktxContext = new KtxLoadContext(imageIndex,www.data);
+                var forceSampleLinear = imageGamma!=null && !imageGamma[imageIndex];
+                var transcodeResult = await ktxContext.LoadAndTranscode(forceSampleLinear);
+                if (transcodeResult == ErrorCode.Success) {
+                    var textureResult = ktxContext.CreateTextureAndDispose();
+                    images[imageIndex] = textureResult.texture;
+                    return textureResult.errorCode == ErrorCode.Success;
+                }
             } else {
-                logger?.Error(LogCode.TextureDownloadFailed,www.error,index.ToString());
-                return false;
+                logger?.Error(LogCode.TextureDownloadFailed,www.error,imageIndex.ToString());
             }
+            return false;
         }
 #endif // KTX_UNITY
 
@@ -1212,7 +1224,7 @@ namespace GLTFast {
             Profiler.BeginSample("LoadTexture");
 
             if(isKtx) {
-#if KTX_UNITY
+#if KTX
                 var downloadTask = downloadProvider.Request(url);
                 if(ktxDownloadTasks==null) {
                     ktxDownloadTasks = new Dictionary<int, Task<IDownload>>();
@@ -1459,7 +1471,7 @@ namespace GLTFast {
                     Assert.AreEqual(images.Length,gltfRoot.images.Length);
                 }
                 imageCreateContexts = new List<ImageCreateContext>();
-#if KTX_UNITY
+#if KTX
                 await
 #endif
                 CreateTexturesFromBuffers(gltfRoot.images,gltfRoot.bufferViews,imageCreateContexts);
@@ -1491,23 +1503,9 @@ namespace GLTFast {
                 await CreatePrimitiveContexts(gltfRoot);
             }
 
-#if KTX_UNITY
+#if KTX
             if(ktxLoadContextsBuffer!=null) {
-
-                var ktxTasks = new Task<KtxUnity.TextureResult>[ktxLoadContextsBuffer.Count];
-                for (var i = 0; i < ktxLoadContextsBuffer.Count; i++) {
-                    var ktx = ktxLoadContextsBuffer[i];
-                    var forceSampleLinear = imageGamma!=null && !imageGamma[ktx.imageIndex];
-                    ktxTasks[i] = ktx.LoadKtx(forceSampleLinear);
-                    await deferAgent.BreakPoint();
-                }
-                await Task.WhenAll(ktxTasks);
-
-                for (var i = 0; i < ktxLoadContextsBuffer.Count; i++) {
-                    var ktx = ktxLoadContextsBuffer[i];
-                    images[ktx.imageIndex] = ktxTasks[i].Result.texture;
-                }
-                ktxLoadContextsBuffer.Clear();
+                await ProcessKtxLoadContexts();
             }
 #endif // KTX_UNITY
 
@@ -2156,7 +2154,7 @@ namespace GLTFast {
 #endif
         }
 
-#if KTX_UNITY
+#if KTX
         async Task
 #else
         void
@@ -2184,7 +2182,7 @@ namespace GLTFast {
                     if (img.bufferView >= 0) {
                         
                         if(imgFormat == ImageFormat.KTX) {
-#if KTX_UNITY
+#if KTX
                             Profiler.BeginSample("CreateTexturesFromBuffers.KtxLoadNativeContext");
                             if(ktxLoadContextsBuffer==null) {
                                 ktxLoadContextsBuffer = new List<KtxLoadContextBase>();
@@ -3223,5 +3221,49 @@ namespace GLTFast {
                     return ImageFormat.Unknown;
             }
         }
+        
+#if KTX
+        struct KtxTranscodeTaskWrapper {
+            public int index;
+            public ErrorCode errorCode;
+        }
+
+        static async Task<KtxTranscodeTaskWrapper> KtxLoadAndTranscode(int index, KtxLoadContextBase ktx, bool linear) {
+            return new KtxTranscodeTaskWrapper {
+                index = index,
+                errorCode = await ktx.LoadAndTranscode(linear)
+            };
+        }
+        
+        async Task ProcessKtxLoadContexts() {
+            var maxCount = SystemInfo.processorCount+1;
+
+            var totalCount = ktxLoadContextsBuffer.Count;
+            var startedCount = 0;
+            var ktxTasks = new List<Task<KtxTranscodeTaskWrapper>>(maxCount);
+
+            while (startedCount < totalCount || ktxTasks.Count>0) {
+                while (ktxTasks.Count < maxCount && startedCount < totalCount) {
+                    var ktx = ktxLoadContextsBuffer[startedCount];
+                    var forceSampleLinear = imageGamma != null && !imageGamma[ktx.imageIndex];
+                    ktxTasks.Add(KtxLoadAndTranscode(startedCount, ktx, forceSampleLinear));
+                    startedCount++;
+                    await deferAgent.BreakPoint();
+                }
+                
+                var kTask = await Task.WhenAny(ktxTasks);
+                var i = kTask.Result.index;
+                if (kTask.Result.errorCode == ErrorCode.Success) {
+                    var ktx = ktxLoadContextsBuffer[i];
+                    var result = ktx.CreateTextureAndDispose();
+                    images[ktx.imageIndex] = result.texture;
+                    await deferAgent.BreakPoint();
+                }
+                ktxTasks.Remove(kTask);
+            }
+            
+            ktxLoadContextsBuffer.Clear();
+        }
+#endif
     }
 }

--- a/Runtime/Scripts/GltfImport.cs
+++ b/Runtime/Scripts/GltfImport.cs
@@ -1154,7 +1154,7 @@ namespace GLTFast {
                 var forceSampleLinear = imageGamma!=null && !imageGamma[imageIndex];
                 var transcodeResult = await ktxContext.LoadAndTranscode(forceSampleLinear);
                 if (transcodeResult == ErrorCode.Success) {
-                    var textureResult = ktxContext.CreateTextureAndDispose();
+                    var textureResult = await ktxContext.CreateTextureAndDispose();
                     images[imageIndex] = textureResult.texture;
                     return textureResult.errorCode == ErrorCode.Success;
                 }
@@ -3245,7 +3245,7 @@ namespace GLTFast {
             while (startedCount < totalCount || ktxTasks.Count>0) {
                 while (ktxTasks.Count < maxCount && startedCount < totalCount) {
                     var ktx = ktxLoadContextsBuffer[startedCount];
-                    var forceSampleLinear = imageGamma != null && !imageGamma[ktx.imageIndex];
+                    var forceSampleLinear = imageGamma != null && !imageGamma[ktx.layer];
                     ktxTasks.Add(KtxLoadAndTranscode(startedCount, ktx, forceSampleLinear));
                     startedCount++;
                     await deferAgent.BreakPoint();
@@ -3255,8 +3255,8 @@ namespace GLTFast {
                 var i = kTask.Result.index;
                 if (kTask.Result.errorCode == ErrorCode.Success) {
                     var ktx = ktxLoadContextsBuffer[i];
-                    var result = ktx.CreateTextureAndDispose();
-                    images[ktx.imageIndex] = result.texture;
+                    var result = await ktx.CreateTextureAndDispose();
+                    images[ktx.layer] = result.texture;
                     await deferAgent.BreakPoint();
                 }
                 ktxTasks.Remove(kTask);

--- a/Runtime/Scripts/KtxLoadContext.cs
+++ b/Runtime/Scripts/KtxLoadContext.cs
@@ -34,21 +34,18 @@ namespace GLTFast {
         }
 
         public override async Task<TextureResult> LoadTexture2D(bool linear) {
-            // TODO: pin data and don't create a copy
-            var slice = new NativeArray<byte>(data,KtxNativeInstance.defaultAllocator);
-            
-            var errorCode = ktxTexture.Open(slice);
-            if (errorCode != ErrorCode.Success) {
-                return new TextureResult(errorCode);
-            }
+            using (var array = new ManagedNativeArray(data)) {
+                
+                var errorCode = ktxTexture.Open(array.nativeArray);
+                if (errorCode != ErrorCode.Success) {
+                    return new TextureResult(errorCode);
+                }
 
-            var result = await ktxTexture.LoadTexture2D(linear);
-            
-            slice.Dispose();
-            data = null;
-            
-            ktxTexture.Dispose();
-            return result;
+                var result = await ktxTexture.LoadTexture2D(linear);
+                
+                ktxTexture.Dispose();
+                return result;
+            }
         }
     }
 }

--- a/Runtime/Scripts/KtxLoadContext.cs
+++ b/Runtime/Scripts/KtxLoadContext.cs
@@ -28,29 +28,25 @@ namespace GLTFast {
         byte[] data;
 
         public KtxLoadContext(int index,byte[] data) {
-            layer = index;
+            imageIndex = index;
             this.data = data;
             ktxTexture = new KtxTexture();
         }
 
-        public override async Task<ErrorCode> LoadAndTranscode(bool linear) {
+        public override async Task<TextureResult> LoadTexture2D(bool linear) {
             // TODO: pin data and don't create a copy
             var slice = new NativeArray<byte>(data,KtxNativeInstance.defaultAllocator);
             
-            var result = ktxTexture.Load(slice);
-            if (result != ErrorCode.Success) {
-                return result;
+            var errorCode = ktxTexture.Open(slice);
+            if (errorCode != ErrorCode.Success) {
+                return new TextureResult(errorCode);
             }
 
-            result = await ktxTexture.Transcode(linear);
+            var result = await ktxTexture.LoadTexture2D(linear);
             
             slice.Dispose();
             data = null;
-            return result;
-        }
-
-        public override async Task<TextureResult> CreateTextureAndDispose() {
-            var result = await ktxTexture.CreateTexture();
+            
             ktxTexture.Dispose();
             return result;
         }

--- a/Runtime/Scripts/KtxLoadContext.cs
+++ b/Runtime/Scripts/KtxLoadContext.cs
@@ -28,7 +28,7 @@ namespace GLTFast {
         byte[] data;
 
         public KtxLoadContext(int index,byte[] data) {
-            this.imageIndex = index;
+            layer = index;
             this.data = data;
             ktxTexture = new KtxTexture();
         }
@@ -49,8 +49,8 @@ namespace GLTFast {
             return result;
         }
 
-        public override TextureResult CreateTextureAndDispose() {
-            var result = ktxTexture.CreateTexture();
+        public override async Task<TextureResult> CreateTextureAndDispose() {
+            var result = await ktxTexture.CreateTexture();
             ktxTexture.Dispose();
             return result;
         }

--- a/Runtime/Scripts/KtxLoadContextBase.cs
+++ b/Runtime/Scripts/KtxLoadContextBase.cs
@@ -13,7 +13,11 @@
 // limitations under the License.
 //
 
-#if KTX_UNITY
+#if KTX_UNITY_2_2_OR_NEWER || (!UNITY_2021_2_OR_NEWER && KTX_UNITY_1_3_OR_NEWER)
+#define KTX
+#endif
+
+#if KTX
 
 using System.Collections;
 using System.Threading.Tasks;
@@ -25,7 +29,8 @@ namespace GLTFast {
         public int imageIndex;
         protected KtxTexture ktxTexture;
         
-        public abstract Task<TextureResult> LoadKtx(bool linear);
+        public abstract Task<ErrorCode> LoadAndTranscode(bool linear);
+        public abstract TextureResult CreateTextureAndDispose();
     }
 }
 #endif // KTX_UNITY

--- a/Runtime/Scripts/KtxLoadContextBase.cs
+++ b/Runtime/Scripts/KtxLoadContextBase.cs
@@ -26,11 +26,11 @@ using UnityEngine;
 
 namespace GLTFast {
     abstract class KtxLoadContextBase {
-        public int imageIndex;
+        public int layer;
         protected KtxTexture ktxTexture;
         
         public abstract Task<ErrorCode> LoadAndTranscode(bool linear);
-        public abstract TextureResult CreateTextureAndDispose();
+        public abstract Task<TextureResult> CreateTextureAndDispose();
     }
 }
 #endif // KTX_UNITY

--- a/Runtime/Scripts/KtxLoadContextBase.cs
+++ b/Runtime/Scripts/KtxLoadContextBase.cs
@@ -19,18 +19,16 @@
 
 #if KTX
 
-using System.Collections;
 using System.Threading.Tasks;
 using KtxUnity;
 using UnityEngine;
 
 namespace GLTFast {
     abstract class KtxLoadContextBase {
-        public int layer;
+        public int imageIndex;
         protected KtxTexture ktxTexture;
         
-        public abstract Task<ErrorCode> LoadAndTranscode(bool linear);
-        public abstract Task<TextureResult> CreateTextureAndDispose();
+        public abstract Task<TextureResult> LoadTexture2D(bool linear);
     }
 }
 #endif // KTX_UNITY

--- a/Runtime/Scripts/KtxLoadNativeContext.cs
+++ b/Runtime/Scripts/KtxLoadNativeContext.cs
@@ -13,7 +13,11 @@
 // limitations under the License.
 //
 
-#if KTX_UNITY
+#if KTX_UNITY_2_2_OR_NEWER || (!UNITY_2021_2_OR_NEWER && KTX_UNITY_1_3_OR_NEWER)
+#define KTX
+#endif
+
+#if KTX
 
 using System.Threading.Tasks;
 using KtxUnity;
@@ -29,8 +33,20 @@ namespace GLTFast {
             ktxTexture = new KtxTexture();
         }
 
-        public override async Task<TextureResult> LoadKtx(bool linear) {
-            return await ktxTexture.LoadBytesRoutine(slice,linear);
+        public override async Task<ErrorCode> LoadAndTranscode(bool linear) {
+            var result = ktxTexture.Load(slice);
+            if (result != ErrorCode.Success) {
+                return result;
+            }
+
+            result = await ktxTexture.Transcode(linear);
+            return result;
+        }
+
+        public override TextureResult CreateTextureAndDispose() {
+            var result = ktxTexture.CreateTexture();
+            ktxTexture.Dispose();
+            return result;
         }
     }
 }

--- a/Runtime/Scripts/KtxLoadNativeContext.cs
+++ b/Runtime/Scripts/KtxLoadNativeContext.cs
@@ -28,23 +28,18 @@ namespace GLTFast {
         NativeSlice<byte> slice;
 
         public KtxLoadNativeContext(int index,NativeSlice<byte> slice) {
-            layer = index;
+            imageIndex = index;
             this.slice = slice;
             ktxTexture = new KtxTexture();
         }
 
-        public override async Task<ErrorCode> LoadAndTranscode(bool linear) {
-            var result = ktxTexture.Load(slice);
-            if (result != ErrorCode.Success) {
-                return result;
+        public override async Task<TextureResult> LoadTexture2D(bool linear) {
+            var errorCode = ktxTexture.Open(slice);
+            if (errorCode != ErrorCode.Success) {
+                return new TextureResult(errorCode);
             }
 
-            result = await ktxTexture.Transcode(linear);
-            return result;
-        }
-
-        public override async Task<TextureResult> CreateTextureAndDispose() {
-            var result = await ktxTexture.CreateTexture();
+            var result = await ktxTexture.LoadTexture2D(linear);
             ktxTexture.Dispose();
             return result;
         }

--- a/Runtime/Scripts/KtxLoadNativeContext.cs
+++ b/Runtime/Scripts/KtxLoadNativeContext.cs
@@ -28,7 +28,7 @@ namespace GLTFast {
         NativeSlice<byte> slice;
 
         public KtxLoadNativeContext(int index,NativeSlice<byte> slice) {
-            this.imageIndex = index;
+            layer = index;
             this.slice = slice;
             ktxTexture = new KtxTexture();
         }
@@ -43,8 +43,8 @@ namespace GLTFast {
             return result;
         }
 
-        public override TextureResult CreateTextureAndDispose() {
-            var result = ktxTexture.CreateTexture();
+        public override async Task<TextureResult> CreateTextureAndDispose() {
+            var result = await ktxTexture.CreateTexture();
             ktxTexture.Dispose();
             return result;
         }

--- a/Runtime/Scripts/Material/MaterialGenerator.cs
+++ b/Runtime/Scripts/Material/MaterialGenerator.cs
@@ -308,6 +308,7 @@ namespace GLTFast.Materials {
             bool flipY = false
             )
         {
+            var hasTransform = false;
             // Scale (x,y) and Transform (z,w)
             float4 textureST = new float4(
                 1,1,// scale
@@ -316,10 +317,8 @@ namespace GLTFast.Materials {
 
             var texCoord = textureInfo.texCoord;
 
-            if(textureInfo.extensions != null && textureInfo.extensions.KHR_texture_transform!=null) {
-                
-                material.EnableKeyword(KW_TEXTURE_TRANSFORM);
-                
+            if(textureInfo.extensions?.KHR_texture_transform != null) {
+                hasTransform = true;
                 var tt = textureInfo.extensions.KHR_texture_transform;
                 if (tt.texCoord >= 0) {
                     texCoord = tt.texCoord;
@@ -367,10 +366,15 @@ namespace GLTFast.Materials {
             }
             
             if(flipY) {
+                hasTransform = true;
                 textureST.w = 1-textureST.w; // flip offset in Y
                 textureST.y = -textureST.y; // flip scale in Y
             }
 
+            if (hasTransform) {
+                material.EnableKeyword(KW_TEXTURE_TRANSFORM);
+            }
+            
             material.SetTextureOffset(texturePropertyId, textureST.zw);
             material.SetTextureScale(texturePropertyId, textureST.xy);
             Assert.IsTrue(scaleTransformPropertyId >= 0,"Texture scale/transform property invalid!");

--- a/Runtime/Scripts/glTFast.asmdef
+++ b/Runtime/Scripts/glTFast.asmdef
@@ -28,8 +28,18 @@
         },
         {
             "name": "com.atteneder.ktx",
-            "expression": "1.1.0",
+            "expression": "",
             "define": "KTX_UNITY"
+        },
+        {
+            "name": "com.atteneder.ktx",
+            "expression": "1.3.0",
+            "define": "KTX_UNITY_1_3_OR_NEWER"
+        },
+        {
+            "name": "com.atteneder.ktx",
+            "expression": "2.2.0",
+            "define": "KTX_UNITY_2_2_OR_NEWER"
         },
         {
             "name": "com.unity.render-pipelines.universal",


### PR DESCRIPTION
feat: Loading many KTX textures is now not blocking the main thread anymore. Requires experimental KtxUnity version (1.3.0 or 2.2.0) respectively and is blocked by their release.