### PR TITLE
Add mesh primitive count check when assigning materials on GLTF export.

### DIFF
--- a/Runtime/Scripts/Export/GltfWriter.cs
+++ b/Runtime/Scripts/Export/GltfWriter.cs
@@ -588,7 +588,7 @@ namespace GLTFast.Export {
         }
 
         static void AssignMaterialsToMesh(int[] materialIds, Mesh mesh) {
-            for (var i = 0; i < materialIds.Length; i++) {
+            for (var i = 0; i < materialIds.Length && i < mesh.primitives.Length; i++) {
                 mesh.primitives[i].material = materialIds[i] >= 0 ? materialIds[i] : -1;
             }
         }


### PR DESCRIPTION
When trying to export models from the Unity asset store I was encountering issues with meshes that had more materials assigned than sub-meshes. 

Adding the change in this PR allows the export to take place, though admittedly won't apply the final material to its assigned sub-mesh.