### PR TITLE
fix: If camera has a targetTexture, use its resolution to calculate x…

### DIFF
--- a/Runtime/Scripts/Export/GltfWriter.cs
+++ b/Runtime/Scripts/Export/GltfWriter.cs
@@ -181,9 +181,17 @@ namespace GLTFast.Export {
             if (uCamera.orthographic) {
                 camera.typeEnum = Camera.Type.Orthographic;
                 var oSize = uCamera.orthographicSize;
+                var aspectRatio = 1f;
+                var targetTexture = uCamera.targetTexture;
+                if (targetTexture == null) {
+                    aspectRatio = Screen.width / (float) Screen.height; 
+                }
+                else {
+                    aspectRatio = targetTexture.width / (float) targetTexture.height;
+                }
                 camera.orthographic = new CameraOrthographic {
                     ymag = oSize,
-                    xmag = oSize * Screen.width / Screen.height,
+                    xmag = oSize * aspectRatio,
                     // TODO: Check if local scale should be applied to near/far
                     znear = uCamera.nearClipPlane,
                     zfar = uCamera.farClipPlane


### PR DESCRIPTION
…mag and ymag