### PR TITLE
Feat: Add Animator component when object has animations set to Mecanim

### DIFF
--- a/Runtime/Scripts/GameObjectInstantiator.cs
+++ b/Runtime/Scripts/GameObjectInstantiator.cs
@@ -402,6 +402,9 @@ namespace GLTFast {
                     }
                     animation.Play();
                 }
+                else {
+                    go.AddComponent<Animator>();
+                }
             }
 #endif // UNITY_ANIMATION
         }


### PR DESCRIPTION
As the name says, makes sure an Animator component is added to imported models when they have animations that are not legacy animations.