### PR TITLE
Minor fix of the documentation

### DIFF
--- a/Documentation~/features.md
+++ b/Documentation~/features.md
@@ -124,7 +124,7 @@ The glTF 2.0 specification is fully supported, with only a few minor remarks.
 | KHR_texture_transform | ✅ | ✅
 | KHR_mesh_quantization | ✅ | 
 | KHR_texture_basisu | ✅ | 
-| KHR_lights_punctual | ✅ | 
+| KHR_lights_punctual | ✅ | ✅
 | KHR_materials_clearcoat | [ℹ️][ClearCoat] | 
 | KHR_materials_sheen | [ℹ️][Sheen] | 
 | KHR_materials_transmission | [ℹ️][Transmission] | 


### PR DESCRIPTION
KHR_lights_punctual is supported for export here: https://github.com/atteneder/glTFast/commit/41793698a2c6f53bd8b480305578e747c4127056