### PR TITLE
feat(export): Texture coordinates are now flipped vertically, similar…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- (Export) Texture coordinates are now flipped vertically, similar to how it's performed at import. This ensures round-trip consistency (#342).
+
 ## [5.0.0] - 2022-12-09
 This release contains multiple breaking changes. Please read the [upgrade guide](xref:doc-upgrade-guides#upgrade-to-50) for details.
 ### Added

--- a/Runtime/Scripts/Export/ExportJobs.cs
+++ b/Runtime/Scripts/Export/ExportJobs.cs
@@ -122,5 +122,29 @@ namespace GLTFast.Export
                 *outPtr = tmp;
             }
         }
+
+        [BurstCompile]
+        public unsafe struct ConvertTexCoordFloatJob : IJobParallelFor
+        {
+            public uint byteStride;
+
+            [ReadOnly]
+            [NativeDisableUnsafePtrRestriction]
+            public byte* input;
+
+            [WriteOnly]
+            [NativeDisableUnsafePtrRestriction]
+            public byte* output;
+
+            public void Execute(int i)
+            {
+                var inPtr = (float2*)(input + i * byteStride);
+                var outPtr = (float2*)(output + i * byteStride);
+
+                var tmp = *inPtr;
+                tmp.y = 1 - tmp.y;
+                *outPtr = tmp;
+            }
+        }
     }
 }

--- a/Runtime/Scripts/Export/MaterialExportBase.cs
+++ b/Runtime/Scripts/Export/MaterialExportBase.cs
@@ -297,11 +297,6 @@ namespace GLTFast.Export
             var offset = mat.GetTextureOffset(texPropertyId);
             var scale = mat.GetTextureScale(texPropertyId);
 
-            // Counter measure for Unity/glTF texture coordinate difference
-            // TODO: Offer UV conversion as alternative
-            offset.y = 1 - offset.y;
-            scale.y *= -1;
-
             if (offset != Vector2.zero || scale != Vector2.one)
             {
                 gltf.RegisterExtensionUsage(Extension.TextureTransform);


### PR DESCRIPTION
… to how it's performed at import. This ensures round-trip consistency (fixes #342).