### PR TITLE
fix(export): Invalid blend indices or blend weights are not exported …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - (Export) Texture coordinates are now flipped vertically, similar to how it's performed at import. This ensures round-trip consistency (#342).
+### Fixed
+- (Export) Invalid blend indices or blend weights are not exported anymore (as skinning is not supported yet; #556)
 
 ## [5.0.0] - 2022-12-09
 This release contains multiple breaking changes. Please read the [upgrade guide](xref:doc-upgrade-guides#upgrade-to-50) for details.

--- a/Runtime/Scripts/Export/GltfWriter.cs
+++ b/Runtime/Scripts/Export/GltfWriter.cs
@@ -924,6 +924,11 @@ namespace GLTFast.Export
             var attrDataDict = new Dictionary<VertexAttribute, AttributeData>();
 
             foreach (var attribute in vertexAttributes) {
+                if (attribute.attribute is VertexAttribute.BlendWeight or VertexAttribute.BlendIndices) {
+                    Debug.LogWarning($"Vertex attribute {attribute.attribute} is not supported yet...skipping");
+                    continue;
+                }
+
                 var attrData = new AttributeData {
                     offset = strides[attribute.stream],
                     stream = attribute.stream


### PR DESCRIPTION
…anymore (as skinning is not supported yet; fixes #556)