### PR TITLE
fix: Shader 'glTF/PbrMetallicRoughness' doesn't have _MainTex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Compiler error when using .NET Framework on 2021.3 and newer (#550)
 - `GltfBoundsAsset`'s instantiation settings are applied now
 - `GltfBoundsAsset`'s `BoxCollider` is positioned correctly, even if GameObject is not at scene origin (#565)
+- Shader 'glTF/PbrMetallicRoughness' doesn't have a texture property '_MainTex' in build-in pipline
 
 ## [5.0.0] - 2022-12-09
 This release contains multiple breaking changes. Please read the [upgrade guide](xref:doc-upgrade-guides#upgrade-to-50) for details.

--- a/Runtime/Shader/Built-In/glTFPbrMetallicRoughness.shader
+++ b/Runtime/Shader/Built-In/glTFPbrMetallicRoughness.shader
@@ -19,6 +19,7 @@ Shader "glTF/PbrMetallicRoughness"
 {
     Properties
     {
+        [HideInInspector] _MainTex ("My Texture", 2D) = "white" { }
         [MainColor] baseColorFactor("Base Color", Color) = (1,1,1,1)
         [MainTexture] baseColorTexture("Base Color Tex", 2D) = "white" {}
         baseColorTexture_Rotation ("Base Color Tex Rotation", Vector) = (0,0,0,0)

--- a/Runtime/Shader/Built-In/glTFPbrSpecularGlossiness.shader
+++ b/Runtime/Shader/Built-In/glTFPbrSpecularGlossiness.shader
@@ -19,6 +19,7 @@ Shader "glTF/PbrSpecularGlossiness"
 {
     Properties
     {
+        [HideInInspector] _MainTex ("My Texture", 2D) = "white" { }
         [MainColor] baseColorFactor("Diffuse", Color) = (1,1,1,1)
         [MainTexture] baseColorTexture("Diffuse Tex", 2D) = "white" {}
         baseColorTexture_Rotation ("Diffuse Tex Rotation", Vector) = (0,0,0,0)

--- a/Runtime/Shader/Built-In/glTFUnlit.shader
+++ b/Runtime/Shader/Built-In/glTFUnlit.shader
@@ -22,6 +22,7 @@
 
 Shader "glTF/Unlit" {
 Properties {
+    [HideInInspector] _MainTex ("My Texture", 2D) = "white" { }
     [MainColor] baseColorFactor ("Main Color", Color) = (1,1,1,1)
     [MainTexture] baseColorTexture ("Base (RGB)", 2D) = "white" {}
     baseColorTexture_Rotation ("Texture rotation", Vector) = (0,0,0,0)


### PR DESCRIPTION
Shader 'glTF/PbrMetallicRoughness' doesn't have a texture property '_MainTex' fixed