### PR TITLE
Fix: builtin forward simple shader 

### DIFF
--- a/Runtime/Shader/Built-In/glTFIncludes/glTFUnityStandardCoreForwardSimple.cginc
+++ b/Runtime/Shader/Built-In/glTFIncludes/glTFUnityStandardCoreForwardSimple.cginc
@@ -110,14 +110,15 @@ VertexOutputBaseSimple vertForwardBaseSimple (VertexInput v)
 {
     UNITY_SETUP_INSTANCE_ID(v);
     VertexOutputBaseSimple o;
+    UNITY_INITIALIZE_OUTPUT(VertexOutputBaseSimple, o);
+    UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+	
 #ifdef UNITY_COLORSPACE_GAMMA
     o.color.rgb = LinearToGammaSpace(v.color.rgb);
     o.color.a = v.color.a;
 #else
     o.color = v.color;
 #endif
-    UNITY_INITIALIZE_OUTPUT(VertexOutputBaseSimple, o);
-    UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
 
     float4 posWorld = mul(unity_ObjectToWorld, v.vertex);
     o.pos = UnityObjectToClipPos(v.vertex);


### PR DESCRIPTION
fixes #594

Move code which set the vertex color after the code which initialize vertex color to zero.
So that vertex color is correctly set.