### PR TITLE
Export simple skybox gltf

### DIFF
--- a/Editor/Scripts/AsyncHelpers.cs
+++ b/Editor/Scripts/AsyncHelpers.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 namespace GLTFast.Utils
 {
 
-    static class AsyncHelpers
+    public static class AsyncHelpers
     {
         /// <summary>
         /// Executes an async Task&lt;T&gt; method which has a void return value synchronously

--- a/Editor/Scripts/Exporter.cs
+++ b/Editor/Scripts/Exporter.cs
@@ -1,0 +1,61 @@
+using System;
+using GLTFast.Utils;
+using GLTFast.Logging;
+using GLTFast.Export;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace GLTFast.Editor
+{
+    public static class Exporter
+    {
+        static readonly string k_GltfExtension = "gltf";
+        static readonly string k_GltfBinaryExtension = "glb";
+
+        public static bool ExportScene(
+            bool binary,
+            string exportFolderPath,
+            string sceneName,
+            ExportSettings exportSettings = null,
+            GameObjectExportSettings gameObjectExportSettings = null
+        )
+        {
+            var scene = SceneManager.GetActiveScene();
+            var gameObjects = scene.GetRootGameObjects();
+            var ext = binary ? k_GltfBinaryExtension : k_GltfExtension;
+            if (exportSettings == null)
+                exportSettings = new ExportSettings
+                {
+                    Format = binary ? GltfFormat.Binary : GltfFormat.Json
+                };
+
+            if (gameObjectExportSettings == null)
+                gameObjectExportSettings = new GameObjectExportSettings { };
+
+            try
+            {
+                System.IO.Directory.CreateDirectory(exportFolderPath);
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"Error creating export folder: {e}");
+            }
+
+            var path = System.IO.Path.Combine(exportFolderPath, $"{sceneName}.{ext}");
+
+            bool success = false;
+            if (!string.IsNullOrEmpty(path))
+            {
+                var export = new GameObjectExport(
+                    exportSettings,
+                    gameObjectExportSettings,
+                    logger: new ConsoleLogger()
+                );
+                export.AddScene(gameObjects, sceneName);
+                success = AsyncHelpers.RunSync(() => export.SaveToFileAndDispose(path));
+            }
+
+            return success;
+        }
+    }
+}

--- a/Editor/Scripts/Exporter.cs.meta
+++ b/Editor/Scripts/Exporter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 23b460eaaad9442e2968beaddf2abd54
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Scripts/glTFast.Editor.asmdef
+++ b/Editor/Scripts/glTFast.Editor.asmdef
@@ -1,12 +1,14 @@
 {
     "name": "glTFast.Editor",
+    "rootNamespace": "",
     "references": [
         "Unity.Mathematics",
         "glTFast",
         "glTFast.Export",
         "UnityEngine.TestTools.Graphics",
         "Unity.RenderPipelines.HighDefinition.Runtime",
-        "com.unity.formats.gltf.validator.Editor"
+        "com.unity.formats.gltf.validator.Editor",
+        "Area28.Unity.Guid"
     ],
     "includePlatforms": [
         "Editor"

--- a/Runtime/Scripts/Export/GameObjectExport.cs
+++ b/Runtime/Scripts/Export/GameObjectExport.cs
@@ -172,12 +172,15 @@ namespace GLTFast.Export
 
             if (onIncludedLayer || children != null)
             {
+                gameObject.TryGetComponent<A28.GuidComponent>(out A28.GuidComponent guidComponent);
+                string guid = guidComponent?.GuidString;
                 nodeId = (int)m_Writer.AddNode(
                     transform.localPosition,
                     transform.localRotation,
                     transform.localScale,
                     children,
-                    gameObject.name
+                    gameObject.name,
+                    guid
                     );
 
                 if (onIncludedLayer)

--- a/Runtime/Scripts/Export/GltfWriter.cs
+++ b/Runtime/Scripts/Export/GltfWriter.cs
@@ -149,12 +149,13 @@ namespace GLTFast.Export
             quaternion? rotation = null,
             float3? scale = null,
             uint[] children = null,
-            string name = null
+            string name = null,
+            string guid = null
         )
         {
             CertifyNotDisposed();
             m_State = State.ContentAdded;
-            var node = CreateNode(translation, rotation, scale, name);
+            var node = CreateNode(translation, rotation, scale, name, guid);
             node.children = children;
             m_Nodes = m_Nodes ?? new List<Node>();
             m_Nodes.Add(node);
@@ -1866,11 +1867,12 @@ namespace GLTFast.Export
             float3? translation = null,
             quaternion? rotation = null,
             float3? scale = null,
-            string name = null
+            string name = null,
+            string guid = null
         )
         {
             var parent = m_Nodes[parentId];
-            var node = CreateNode(translation, rotation, scale, name);
+            var node = CreateNode(translation, rotation, scale, name, guid);
             m_Nodes.Add(node);
             var nodeId = (uint)m_Nodes.Count - 1;
             if (parent.children == null)
@@ -1891,12 +1893,14 @@ namespace GLTFast.Export
             float3? translation = null,
             quaternion? rotation = null,
             float3? scale = null,
-            string name = null
+            string name = null,
+            string guid = null
             )
         {
             var node = new Node
             {
                 name = name,
+                guid = guid
             };
             if (translation.HasValue && !translation.Equals(float3.zero))
             {

--- a/Runtime/Scripts/Export/GltfWriter.cs
+++ b/Runtime/Scripts/Export/GltfWriter.cs
@@ -1900,7 +1900,7 @@ namespace GLTFast.Export
             var node = new Node
             {
                 name = name,
-                guid = guid
+                extras = new Node.Extras(guid)
             };
             if (translation.HasValue && !translation.Equals(float3.zero))
             {

--- a/Runtime/Scripts/Export/IGltfWritable.cs
+++ b/Runtime/Scripts/Export/IGltfWritable.cs
@@ -42,7 +42,8 @@ namespace GLTFast.Export
             quaternion? rotation = null,
             float3? scale = null,
             uint[] children = null,
-            string name = null
+            string name = null,
+            string guid = null
         );
 
         /// <summary>

--- a/Runtime/Scripts/Export/glTFast.Export.asmdef
+++ b/Runtime/Scripts/Export/glTFast.Export.asmdef
@@ -1,11 +1,13 @@
 {
     "name": "glTFast.Export",
+    "rootNamespace": "",
     "references": [
         "glTFast",
         "Unity.Mathematics",
         "Unity.Burst",
         "Unity.RenderPipelines.Universal.Runtime",
-        "Unity.RenderPipelines.HighDefinition.Runtime"
+        "Unity.RenderPipelines.HighDefinition.Runtime",
+        "Area28.Unity.Guid"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Runtime/Scripts/GameObjectInstantiator.cs
+++ b/Runtime/Scripts/GameObjectInstantiator.cs
@@ -22,6 +22,7 @@ using UnityEngine.Profiling;
 using Camera = UnityEngine.Camera;
 using Material = UnityEngine.Material;
 using Mesh = UnityEngine.Mesh;
+using A28;
 
 // #if UNITY_EDITOR && UNITY_ANIMATION
 // using UnityEditor.Animations;
@@ -195,7 +196,8 @@ namespace GLTFast
             uint? parentIndex,
             Vector3 position,
             Quaternion rotation,
-            Vector3 scale
+            Vector3 scale,
+            string guid
         )
         {
             var go = new GameObject();
@@ -210,6 +212,10 @@ namespace GLTFast
             go.transform.SetParent(
                 parentIndex.HasValue ? m_Nodes[parentIndex.Value].transform : SceneTransform,
                 false);
+
+            if (guid == null) return;
+            var guidComponent = go.AddComponent<GuidComponent>();
+            guidComponent.GuidString = guid;
         }
 
         /// <inheritdoc />

--- a/Runtime/Scripts/GltfImport.cs
+++ b/Runtime/Scripts/GltfImport.cs
@@ -2275,7 +2275,7 @@ namespace GLTFast
                 Profiler.BeginSample("CreateHierarchy");
                 var node = m_GltfRoot.nodes[nodeIndex];
                 node.GetTransform(out var position, out var rotation, out var scale);
-                instantiator.CreateNode(nodeIndex, parentIndex, position, rotation, scale);
+                instantiator.CreateNode(nodeIndex, parentIndex, position, rotation, scale, node.extras.guid);
                 Profiler.EndSample();
             }
 

--- a/Runtime/Scripts/IInstantiator.cs
+++ b/Runtime/Scripts/IInstantiator.cs
@@ -63,7 +63,8 @@ namespace GLTFast
             uint? parentIndex,
             Vector3 position,
             Quaternion rotation,
-            Vector3 scale
+            Vector3 scale,
+            string guid
             );
 
         /// <summary>

--- a/Runtime/Scripts/Schema/JsonWriter.cs
+++ b/Runtime/Scripts/Schema/JsonWriter.cs
@@ -48,6 +48,12 @@ namespace GLTFast.Schema
             m_Stream.Write("\":");
             m_Separation = false;
         }
+        public void AddGuid(string guid)
+        {
+            Separate();
+            m_Stream.Write($@"""extras"": {{""guid"": ""{guid}""}}");
+            m_Separation = false;
+        }
 
         public void AddObject()
         {

--- a/Runtime/Scripts/Schema/Material.cs
+++ b/Runtime/Scripts/Schema/Material.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 //
 
+using Newtonsoft.Json;
 using Unity.Mathematics;
 using UnityEngine;
 
@@ -51,6 +52,32 @@ namespace GLTFast.Schema
             /// using the normal painting operation.
             /// </summary>
             Blend
+        }
+
+        /// <summary>
+        /// The material's skybox mode enumeration specifying the type of skybox
+        /// and usage of the attached texture(s)
+        /// </summary>
+        public enum SkyboxMode
+        {
+            /// <summary>
+            /// In 6-sided mode, 6 textures are provided to form the cube map.
+            /// </summary>
+            SixSided,
+
+            /// <summary>
+            /// In cube map mode, a single equi-rectangular texture is used
+            /// to create the cube map. This mode is combined with Unity's
+            /// Panoramic skybox, since the texture usage is the same.
+            /// </summary>
+            CubeMap,
+
+            /// <summary>
+            /// Procedural skyboxes are created with code rather than textures,
+            /// so the relevant properties are specified for skybox replication
+            /// upon import.
+            /// </summary>
+            Procedural
         }
 
         /// <summary>
@@ -166,6 +193,21 @@ namespace GLTFast.Schema
         }
 
         /// <summary>
+        /// Structure to store skybox material properties
+        /// </summary>
+        public struct SkyboxStruct
+        {
+            public bool isSkybox;
+            public SkyboxMode skyboxMode;
+            public override string ToString()
+            {
+                return JsonConvert.SerializeObject(this);
+            }
+        };
+
+        public SkyboxStruct skyboxStruct;
+
+        /// <summary>
         /// Specifies the cutoff threshold when in `MASK` mode. If the alpha value is greater than
         /// or equal to this value then it is rendered as fully opaque, otherwise, it is rendered
         /// as fully transparent. This value is ignored for other modes.
@@ -234,6 +276,10 @@ namespace GLTFast.Schema
             if (doubleSided)
             {
                 writer.AddProperty("doubleSided", doubleSided);
+            }
+            if (skyboxStruct.isSkybox)
+            {
+                writer.AddProperty("extras", skyboxStruct);
             }
             if (extensions != null)
             {

--- a/Runtime/Scripts/Schema/Node.cs
+++ b/Runtime/Scripts/Schema/Node.cs
@@ -73,6 +73,8 @@ namespace GLTFast.Schema
         /// <inheritdoc cref="NodeExtensions"/>
         public NodeExtensions extensions;
 
+        public string guid = null;
+
         internal void GltfSerialize(JsonWriter writer)
         {
             writer.AddObject();
@@ -122,6 +124,11 @@ namespace GLTFast.Schema
             {
                 writer.AddProperty("extensions");
                 extensions.GltfSerialize(writer);
+            }
+
+            if (guid != null)
+            {
+                writer.AddGuid(guid);
             }
             writer.Close();
         }

--- a/Runtime/Scripts/Schema/Node.cs
+++ b/Runtime/Scripts/Schema/Node.cs
@@ -73,7 +73,18 @@ namespace GLTFast.Schema
         /// <inheritdoc cref="NodeExtensions"/>
         public NodeExtensions extensions;
 
-        public string guid = null;
+        public Extras extras;
+
+        [System.Serializable]
+        public class Extras
+        {
+            public string guid;
+
+            public Extras(string guid)
+            {
+                this.guid = guid;
+            }
+        }
 
         internal void GltfSerialize(JsonWriter writer)
         {
@@ -126,9 +137,9 @@ namespace GLTFast.Schema
                 extensions.GltfSerialize(writer);
             }
 
-            if (guid != null)
+            if (extras.guid != null)
             {
-                writer.AddGuid(guid);
+                writer.AddGuid(extras.guid);
             }
             writer.Close();
         }

--- a/Runtime/Scripts/glTFast.asmdef
+++ b/Runtime/Scripts/glTFast.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "glTFast",
+    "rootNamespace": "",
     "references": [
         "Unity.Mathematics",
         "Unity.Burst",
@@ -9,7 +10,8 @@
         "Ktx",
         "Unity.Meshopt.Decompress",
         "Unity.RenderPipelines.Universal.Runtime",
-        "Unity.RenderPipelines.HighDefinition.Runtime"
+        "Unity.RenderPipelines.HighDefinition.Runtime",
+        "Area28.Unity.Guid"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Tests/Editor/JsonParsingTests.cs
+++ b/Tests/Editor/JsonParsingTests.cs
@@ -471,5 +471,32 @@ namespace GLTFast.Tests
             gltf = JsonParser.ParseJson(@"garbage");
             Assert.IsNull(gltf);
         }
+        
+        [Test]
+        public void A28Guid()
+        {
+            var gltf = JsonParser.ParseJson(@"
+{
+    ""nodes"": [
+        {
+            ""extensions"": {},
+            ""name"": ""Node1"",
+            ""extras"": {""guid"": ""48a855b4b5934f7aa9e0ece96e8fcfaf""}
+        }
+    ]
+}
+"
+            );
+
+            Assert.NotNull(gltf);
+            Assert.NotNull(gltf.nodes, "No nodes");
+            Assert.AreEqual(1, gltf.nodes.Length, "Invalid nodes quantity");
+
+            var node = gltf.nodes[0];
+            Assert.NotNull(node);
+            Assert.NotNull(node.extras);
+            Assert.NotNull(node.extras.guid);
+            Assert.AreEqual(node.extras.guid, "48a855b4b5934f7aa9e0ece96e8fcfaf", "Guid does not match");
+        }
     }
 }


### PR DESCRIPTION
Currently support exporting Cube Map, Panoramic and Procedural skyboxes. Due to format limitations, certain properties aren't exported but this should work for basic skybox usage.

The implementation for Procedural skybox export is a bit hacky. Not sure if this is OK.

This works in conjunction with skybox import in the Unity viewer (I'll create a PR for that too).

Let me know if you think it's better to have tests.