### PR TITLE
Fix incorrect rendering of first item in report

### DIFF
--- a/Editor/UI/GltfImporter.uxml
+++ b/Editor/UI/GltfImporter.uxml
@@ -24,6 +24,6 @@
     <ui:VisualElement name="Report" class="report section">
         <Style src="GltfImporter-style.uss" />
         <ui:Label text="Report" name="Headline" class="h1" />
-        <ui:ListView focusable="true" binding-path="reportItems" virtualization-method="DynamicHeight" class="report-list" />
+        <ui:ListView focusable="true" binding-path="reportItems" virtualization-method="DynamicHeight" show-bound-collection-size="false" class="report-list" />
     </ui:VisualElement>
 </ui:UXML>


### PR DESCRIPTION
UIToolkit's ListView seems to be quite a mess. With 2022.3.2f1 I had trouble reading the report because the first item is cut off (and strangely not indented like other items). Here's a quick fix.

Before:
![image](https://github.com/atteneder/glTFast/assets/3404365/0c3be316-d95d-4f1c-af5b-10f9e1a25f5d)
![image](https://github.com/atteneder/glTFast/assets/3404365/d6a27738-0d7b-4e30-b258-f81bcd4466c8)

After:
![image](https://github.com/atteneder/glTFast/assets/3404365/91654d85-d8ce-4858-8b4c-414cfe471ef6)
![image](https://github.com/atteneder/glTFast/assets/3404365/75fcd95c-de6f-4d4d-bc46-35b696f8f1e1)

Quickly tested with 2022.3.2f, 2021.3.27f, 2020.3.45f