### PR TITLE
Fix "unreachable code" warning during build

### DIFF
--- a/Runtime/Scripts/GltfImport.cs
+++ b/Runtime/Scripts/GltfImport.cs
@@ -701,8 +701,9 @@ namespace GLTFast
             return defaultMaterial;
 #else
             m_MaterialGenerator.SetLogger(m_Logger);
-            return m_MaterialGenerator.GetDefaultMaterial(m_DefaultMaterialPointsSupport);
+            var defaultMaterial = m_MaterialGenerator.GetDefaultMaterial(m_DefaultMaterialPointsSupport);
             m_MaterialGenerator.SetLogger(null);
+            return defaultMaterial;
 #endif
         }
 


### PR DESCRIPTION
Note: MaterialGenerator's Logger was not reset due to return statement