### PR TITLE
Add support for EXT_texture_webp

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ There are some related package that improve *glTFast* by extending its feature s
 - [Draco 3D Data Compression Unity Package][DracoUnity] (provides support for [KHR_draco_mesh_compression][ExtDraco])
 - [KTX/Basis Texture Unity Package][KtxUnity] (provides support for [KHR_texture_basisu][ExtBasisU])
 - [*meshoptimizer decompression for Unity*][Meshopt] (provides support for [EXT_meshopt_compression][ExtMeshopt])
+- [Unity.WebP][Unity.WebP] (provides support for [EXT_texture_webp][ExtWebP], not affiliated with Unity Technologies)
 
 *glTFast* 5.x requires Unity 2019.3 or newer. For older Unity versions see [Legacy Installation](./Documentation~/gltfast-1.md).
 
@@ -140,6 +141,7 @@ limitations under the License.
 [ExtBasisU]: https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_texture_basisu
 [ExtDraco]: https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_draco_mesh_compression
 [ExtMeshopt]: https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Vendor/EXT_meshopt_compression
+[ExtWebP]: https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Vendor/EXT_texture_webp
 [gltf-spec]: https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html
 [gltf]: https://www.khronos.org/gltf
 [gltfasset_component]: ./Documentation~/Images/gltfasset_component.png  "Inspector showing a GltfAsset component added to a GameObject"
@@ -148,5 +150,6 @@ limitations under the License.
 [khronos]: https://www.khronos.org
 [KtxUnity]: https://github.com/atteneder/KtxUnity
 [Meshopt]: https://docs.unity3d.com/Packages/com.unity.meshopt.decompress@0.1/manual/index.html
+[Unity.WebP]: https://github.com/netpyoung/unity.webp
 [unity]: https://unity.com
 [workflows]: ./Documentation~/index.md#workflows

--- a/Runtime/Scripts/Extensions.cs
+++ b/Runtime/Scripts/Extensions.cs
@@ -57,6 +57,10 @@ namespace GLTFast
         /// <see href="https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_texture_transform/README.md">KHR_texture_transform</see> glTF extension
         /// </summary>
         TextureTransform,
+        /// <summary>
+        /// <see cref="https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Vendor/EXT_texture_webp/README.md">EXT_texture_webp</see> glTF extension
+        /// </summary>
+        TextureWebP
     }
 
     /// <summary>
@@ -104,6 +108,10 @@ namespace GLTFast
         /// <see href="https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_lights_punctual">KHR_lights_punctual</see> glTF extension
         /// </summary>
         public const string LightsPunctual = "KHR_lights_punctual";
+        /// <summary>
+        /// <see cref="https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Vendor/EXT_texture_webp/README.md">WebP</see> glTF extension
+        /// </summary>
+        public const string TextureWebP = "EXT_texture_webp";
 
         /// <summary>
         /// Returns the official name of the glTF extension
@@ -132,6 +140,8 @@ namespace GLTFast
                     return TextureBasisUniversal;
                 case Extension.TextureTransform:
                     return TextureTransform;
+                case Extension.TextureWebP:
+                    return TextureWebP;
                 default:
                     return null;
             }

--- a/Runtime/Scripts/GltfGlobals.cs
+++ b/Runtime/Scripts/GltfGlobals.cs
@@ -23,7 +23,8 @@ namespace GLTFast
         Unknown,
         PNG,
         Jpeg,
-        Ktx
+        Ktx,
+        Webp
     }
 
     enum ChunkFormat : uint

--- a/Runtime/Scripts/GltfImport.cs
+++ b/Runtime/Scripts/GltfImport.cs
@@ -2698,6 +2698,13 @@ namespace GLTFast
                             m_Logger?.Error(LogCode.PackageMissing, "KtxUnity", ExtensionName.TextureBasisUniversal);
 #endif // KTX_UNITY
                         }
+                        else if(imgFormat == ImageFormat.Webp)
+                        {
+#if !WEBP
+                            //TODO: Can we make this just a warning if there is a valid fallback image present for all textures where this is referenced? Applies to KTX as well.
+                            m_Logger?.Error(LogCode.PackageMissing, "Unity.WebP", ExtensionName.TextureWebP);
+#endif
+                        }
                         else
                         {
                             Profiler.BeginSample("CreateTexturesFromBuffers.ExtractBuffer");

--- a/Runtime/Scripts/GltfImport.cs
+++ b/Runtime/Scripts/GltfImport.cs
@@ -22,6 +22,9 @@
 #elif KTX_UNITY
 #warning You have to update KtxUnity to enable support for KTX textures in glTFast
 #endif
+#if KTX || WEBP
+#define IMAGEDOWNLOADS
+#endif
 
 // #define MEASURE_TIMINGS
 
@@ -156,7 +159,7 @@ namespace GLTFast
         GlbBinChunk[] m_BinChunks;
 
         Dictionary<int, Task<IDownload>> m_DownloadTasks;
-#if KTX
+#if IMAGEDOWNLOADS
         Dictionary<int,Task<IDownload>> m_ImageDownloadTasks;
 #endif
         Dictionary<int, TextureDownloadBase> m_TextureDownloadTasks;
@@ -924,12 +927,12 @@ namespace GLTFast
                 m_TextureDownloadTasks.Clear();
             }
 
-#if KTX || WEBP
+#if IMAGEDOWNLOADS
             if (m_ImageDownloadTasks != null) {
                 success = success && await WaitForImageDownloads();
                 m_ImageDownloadTasks.Clear();
             }
-#endif // KTX_UNITY
+#endif
 
             return success;
         }
@@ -1355,7 +1358,7 @@ namespace GLTFast
         }
 
 
-#if KTX || WEBP
+#if IMAGEDOWNLOADS
         async Task<bool> WaitForImageDownloads() {
             var tasks = new Task<bool>[m_ImageDownloadTasks.Count];
             var i = 0;

--- a/Runtime/Scripts/GltfImport.cs
+++ b/Runtime/Scripts/GltfImport.cs
@@ -1357,8 +1357,17 @@ namespace GLTFast
             return true;
         }
 
-
 #if IMAGEDOWNLOADS
+        void AddImageDownloadTask(int imageIndex, Uri url)
+        {
+            var downloadTask = m_DownloadProvider.Request(url);
+            if (m_ImageDownloadTasks == null)
+            {
+                m_ImageDownloadTasks = new Dictionary<int, Task<IDownload>>();
+            }
+            m_ImageDownloadTasks.Add(imageIndex, downloadTask);
+        }
+
         async Task<bool> WaitForImageDownloads() {
             var tasks = new Task<bool>[m_ImageDownloadTasks.Count];
             var i = 0;
@@ -1510,7 +1519,7 @@ namespace GLTFast
                     m_Logger?.Error(LogCode.PackageMissing, "KtxUnity", ExtensionName.TextureBasisUniversal);
                     Profiler.EndSample();
                     return;
-#endif // KTX_UNITY
+#endif
                 case ImageFormat.Webp:
 #if WEBP
                     AddImageDownloadTask(imageIndex, url);
@@ -1536,16 +1545,6 @@ namespace GLTFast
                     break;
             }
             Profiler.EndSample();
-        }
-
-        private void AddImageDownloadTask(int imageIndex, Uri url)
-        {
-            var downloadTask = m_DownloadProvider.Request(url);
-            if (m_ImageDownloadTasks == null)
-            {
-                m_ImageDownloadTasks = new Dictionary<int, Task<IDownload>>();
-            }
-            m_ImageDownloadTasks.Add(imageIndex, downloadTask);
         }
 
         /// <summary>

--- a/Runtime/Scripts/GltfImport.cs
+++ b/Runtime/Scripts/GltfImport.cs
@@ -1807,7 +1807,13 @@ namespace GLTFast
                             if (m_ImageFormats[jh.imageIndex] == ImageFormat.Webp)
                             {
                                 var t = m_Images[jh.imageIndex];
-                                m_Images[jh.imageIndex] = Texture2DExt.CreateTexture2DFromWebP(jh.buffer, t.mipmapCount > 0, t.isDataSRGB, out var webpError, null, !m_ImageReadable[jh.imageIndex]);
+                                var linear =
+#if UNITY_2022_1_OR_NEWER
+                                    t.isDataSRGB;
+#else
+                                    GraphicsFormatUtility.IsSRGBFormat(t.graphicsFormat);
+#endif
+                                m_Images[jh.imageIndex] = Texture2DExt.CreateTexture2DFromWebP(jh.buffer, t.mipmapCount > 0, !linear, out var webpError, null, !m_ImageReadable[jh.imageIndex]);
                                 m_Resources.Remove(t);
                                 m_Resources.Add(m_Images[jh.imageIndex]);
                                 SafeDestroy(t);

--- a/Runtime/Scripts/GltfImport.cs
+++ b/Runtime/Scripts/GltfImport.cs
@@ -1802,8 +1802,26 @@ namespace GLTFast
                         if (jh.jobHandle.IsCompleted)
                         {
                             jh.jobHandle.Complete();
+
+#if WEBP
+                            if (m_ImageFormats[jh.imageIndex] == ImageFormat.Webp)
+                            {
+                                var t = m_Images[jh.imageIndex];
+                                m_Images[jh.imageIndex] = Texture2DExt.CreateTexture2DFromWebP(jh.buffer, t.mipmapCount > 0, t.isDataSRGB, out var webpError, null, !m_ImageReadable[jh.imageIndex]);
+                                m_Resources.Remove(t);
+                                m_Resources.Add(m_Images[jh.imageIndex]);
+                                SafeDestroy(t);
+                                if (webpError != Error.Success)
+                                    throw new Exception($"Webp error: {webpError}");
+                            }
+#endif
+#if WEBP && UNITY_IMAGECONVERSION
+                            else
+#endif
 #if UNITY_IMAGECONVERSION
-                            m_Images[jh.imageIndex].LoadImage(jh.buffer,!m_ImageReadable[jh.imageIndex]);
+                            { 
+                                m_Images[jh.imageIndex].LoadImage(jh.buffer, !m_ImageReadable[jh.imageIndex]);
+                            }
 #endif
                             jh.gcHandle.Free();
                             m_ImageCreateContexts.RemoveAt(i);

--- a/Runtime/Scripts/GltfImport.cs
+++ b/Runtime/Scripts/GltfImport.cs
@@ -3784,6 +3784,8 @@ namespace GLTFast
                 case "ktx":
                 case "ktx2":
                     return ImageFormat.Ktx;
+                case "webp":
+                    return ImageFormat.Webp;
                 default:
                     return ImageFormat.Unknown;
             }

--- a/Runtime/Scripts/GltfImport.cs
+++ b/Runtime/Scripts/GltfImport.cs
@@ -1034,6 +1034,13 @@ namespace GLTFast
                         }
                         else
 #endif
+#if !WEBP
+                        if (ext == ExtensionName.TextureWebP)
+                        {
+                            m_Logger?.Error(LogCode.PackageMissing, "Unity.WebP", ext);
+                        }
+                        else
+#endif
                         {
                             m_Logger?.Error(LogCode.ExtensionUnsupported, ext);
                         }

--- a/Runtime/Scripts/GltfImport.cs
+++ b/Runtime/Scripts/GltfImport.cs
@@ -1868,11 +1868,11 @@ namespace GLTFast
                                 var t = m_Images[jh.imageIndex];
                                 var linear =
 #if UNITY_2022_1_OR_NEWER
-                                    t.isDataSRGB;
+                                    !t.isDataSRGB;
 #else
-                                    GraphicsFormatUtility.IsSRGBFormat(t.graphicsFormat);
+                                    !GraphicsFormatUtility.IsSRGBFormat(t.graphicsFormat);
 #endif
-                                m_Images[jh.imageIndex] = Texture2DExt.CreateTexture2DFromWebP(jh.buffer, t.mipmapCount > 0, !linear, out var webpError, null, !m_ImageReadable[jh.imageIndex]);
+                                m_Images[jh.imageIndex] = Texture2DExt.CreateTexture2DFromWebP(jh.buffer, t.mipmapCount > 0, linear, out var webpError, null, !m_ImageReadable[jh.imageIndex]);
                                 m_Resources.Remove(t);
                                 m_Resources.Add(m_Images[jh.imageIndex]);
                                 SafeDestroy(t);

--- a/Runtime/Scripts/GltfImport.cs
+++ b/Runtime/Scripts/GltfImport.cs
@@ -44,6 +44,9 @@ using KtxUnity;
 #if MESHOPT
 using Meshoptimizer;
 #endif
+#if WEBP
+using WebP;
+#endif
 using Unity.Collections.LowLevel.Unsafe;
 using Unity.Collections;
 using Unity.Jobs;
@@ -125,6 +128,9 @@ namespace GLTFast
             ExtensionName.MaterialsTransmission,
             ExtensionName.MeshGPUInstancing,
             ExtensionName.LightsPunctual,
+#if WEBP
+            ExtensionName.TextureWebP
+#endif
         };
 
         static IDeferAgent s_DefaultDeferAgent;

--- a/Runtime/Scripts/JsonParser.cs
+++ b/Runtime/Scripts/JsonParser.cs
@@ -111,6 +111,27 @@ namespace GLTFast
                 }
             }
 #endif
+#if WEBP
+            if (root.textures != null)
+            {
+                for (int i = 0; i < root.textures.Length; i++)
+                {
+                    var tex = root.textures[i];
+                    // tex.extension is always set (not null), because JsonUtility constructs a default
+                    // if any of tex.extension's members is not null, it is because there was
+                    // a legit extensions node in JSON => we have to check which ones
+                    if (tex.extensions.KHR_texture_basisu != null)
+                    {
+                        check = true;
+                    }
+                    else
+                    {
+                        // otherwise dump the wrongfully constructed MaterialExtension
+                        tex.extensions = null;
+                    }
+                }
+            }
+#endif
             Profiler.EndSample();
 
             // Step three:
@@ -189,6 +210,29 @@ namespace GLTFast
                     }
                 }
 #endif
+
+#if WEBP
+                if (root.textures != null)
+                {
+                    for (var i = 0; i < root.textures.Length; i++)
+                    {
+                        var tex = root.textures[i];
+                        if (tex.extensions == null) continue;
+                        Assert.AreEqual(tex.name, fakeRoot.textures[i].name);
+                        var fake = fakeRoot.textures[i].extensions;
+                        if (fake.KHR_texture_basisu == null)
+                        {
+                            tex.extensions.KHR_texture_basisu = null;
+                        }
+
+                        if (fake.EXT_texture_webp == null)
+                        {
+                            tex.extensions.EXT_texture_webp = null;
+                        }
+                    }
+                }
+#endif
+
                 Profiler.EndSample();
             }
 

--- a/Runtime/Scripts/JsonParser.cs
+++ b/Runtime/Scripts/JsonParser.cs
@@ -111,7 +111,6 @@ namespace GLTFast
                 }
             }
 #endif
-#if WEBP
             if (root.textures != null)
             {
                 for (int i = 0; i < root.textures.Length; i++)
@@ -131,7 +130,6 @@ namespace GLTFast
                     }
                 }
             }
-#endif
             Profiler.EndSample();
 
             // Step three:
@@ -211,7 +209,6 @@ namespace GLTFast
                 }
 #endif
 
-#if WEBP
                 if (root.textures != null)
                 {
                     for (var i = 0; i < root.textures.Length; i++)
@@ -224,14 +221,14 @@ namespace GLTFast
                         {
                             tex.extensions.KHR_texture_basisu = null;
                         }
-
+#if WEBP
                         if (fake.EXT_texture_webp == null)
                         {
                             tex.extensions.EXT_texture_webp = null;
                         }
+#endif
                     }
                 }
-#endif
 
                 Profiler.EndSample();
             }

--- a/Runtime/Scripts/Schema/FakeSchema/Root.cs
+++ b/Runtime/Scripts/Schema/FakeSchema/Root.cs
@@ -28,9 +28,7 @@ namespace GLTFast.FakeSchema
         /// </summary>
         public Material[] materials;
 
-#if WEBP
         public Texture[] textures;
-#endif
 
 #if GLTFAST_SAFE
         public Accessor[] accessors;

--- a/Runtime/Scripts/Schema/FakeSchema/Root.cs
+++ b/Runtime/Scripts/Schema/FakeSchema/Root.cs
@@ -28,6 +28,10 @@ namespace GLTFast.FakeSchema
         /// </summary>
         public Material[] materials;
 
+#if WEBP
+        public Texture[] textures;
+#endif
+
 #if GLTFAST_SAFE
         public Accessor[] accessors;
 #endif

--- a/Runtime/Scripts/Schema/FakeSchema/Texture.cs
+++ b/Runtime/Scripts/Schema/FakeSchema/Texture.cs
@@ -1,0 +1,17 @@
+﻿namespace GLTFast.FakeSchema
+{
+    [System.Serializable]
+    class Texture : NamedObject
+    {
+        public TextureExtension extensions;
+    }
+
+    [System.Serializable]
+    class TextureExtension : NamedObject
+    {
+        // ReSharper disable InconsistentNaming
+        public string KHR_texture_basisu;
+        public string EXT_texture_webp;
+        // ReSharper enable InconsistentNaming
+    }
+}

--- a/Runtime/Scripts/Schema/FakeSchema/Texture.cs
+++ b/Runtime/Scripts/Schema/FakeSchema/Texture.cs
@@ -7,11 +7,13 @@
     }
 
     [System.Serializable]
-    class TextureExtension : NamedObject
+    class TextureExtension
     {
         // ReSharper disable InconsistentNaming
         public string KHR_texture_basisu;
+#if WEBP
         public string EXT_texture_webp;
+#endif
         // ReSharper enable InconsistentNaming
     }
 }

--- a/Runtime/Scripts/Schema/FakeSchema/Texture.cs.meta
+++ b/Runtime/Scripts/Schema/FakeSchema/Texture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f68b6cd3bc6eab2449bd5bfc3bd3008d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Schema/Texture.cs
+++ b/Runtime/Scripts/Schema/Texture.cs
@@ -46,16 +46,16 @@ namespace GLTFast.Schema
         {
             if (extensions != null)
             {
+                if (extensions.KHR_texture_basisu != null && extensions.KHR_texture_basisu.source >= 0)
+                {
+                    return extensions.KHR_texture_basisu.source;
+                }
 #if WEBP
                 if (extensions.EXT_texture_webp != null && extensions.EXT_texture_webp.source >= 0)
                 {
                     return extensions.EXT_texture_webp.source;
                 }
 #endif
-                if (extensions.KHR_texture_basisu != null && extensions.KHR_texture_basisu.source >= 0)
-                {
-                    return extensions.KHR_texture_basisu.source;
-                }
             }
             return source;
         }

--- a/Runtime/Scripts/Schema/Texture.cs
+++ b/Runtime/Scripts/Schema/Texture.cs
@@ -46,11 +46,12 @@ namespace GLTFast.Schema
         {
             if (extensions != null)
             {
+#if WEBP
                 if (extensions.EXT_texture_webp != null && extensions.EXT_texture_webp.source >= 0)
                 {
                     return extensions.EXT_texture_webp.source;
                 }
-
+#endif
                 if (extensions.KHR_texture_basisu != null && extensions.KHR_texture_basisu.source >= 0)
                 {
                     return extensions.KHR_texture_basisu.source;

--- a/Runtime/Scripts/Schema/Texture.cs
+++ b/Runtime/Scripts/Schema/Texture.cs
@@ -62,7 +62,7 @@ namespace GLTFast.Schema
         /// <summary>
         /// True, if the texture is of the KTX format.
         /// </summary>
-        public bool IsKtx => extensions?.KHR_texture_basisu != null && extensions.EXT_texture_webp == null;
+        public bool IsKtx => extensions?.KHR_texture_basisu != null;
 
         internal void GltfSerialize(JsonWriter writer)
         {

--- a/Runtime/Scripts/Schema/Texture.cs
+++ b/Runtime/Scripts/Schema/Texture.cs
@@ -62,7 +62,7 @@ namespace GLTFast.Schema
         /// <summary>
         /// True, if the texture is of the KTX format.
         /// </summary>
-        public bool IsKtx => extensions?.KHR_texture_basisu != null;
+        public bool IsKtx => extensions?.KHR_texture_basisu != null && extensions.EXT_texture_webp == null;
 
         internal void GltfSerialize(JsonWriter writer)
         {

--- a/Runtime/Scripts/Schema/Texture.cs
+++ b/Runtime/Scripts/Schema/Texture.cs
@@ -46,6 +46,11 @@ namespace GLTFast.Schema
         {
             if (extensions != null)
             {
+                if (extensions.EXT_texture_webp != null && extensions.EXT_texture_webp.source >= 0)
+                {
+                    return extensions.EXT_texture_webp.source;
+                }
+
                 if (extensions.KHR_texture_basisu != null && extensions.KHR_texture_basisu.source >= 0)
                 {
                     return extensions.KHR_texture_basisu.source;

--- a/Runtime/Scripts/Schema/TextureExtension.cs
+++ b/Runtime/Scripts/Schema/TextureExtension.cs
@@ -27,8 +27,10 @@ namespace GLTFast.Schema
         /// <inheritdoc cref="Extension.TextureBasisUniversal"/>
         public TextureBasisUniversal KHR_texture_basisu;
 
+#if WEBP
         /// <inheritdoc cref="Extension.TextureWebP"/>
         public TextureWebP EXT_texture_webp;
+#endif
         // ReSharper enable InconsistentNaming
 
         internal void GltfSerialize(JsonWriter writer)
@@ -52,6 +54,7 @@ namespace GLTFast.Schema
         public int source = -1;
     }
 
+#if WEBP
     /// <summary>
     /// WebP texture extension
     /// <seealso cref="Extension.TextureWebP"/>
@@ -65,4 +68,5 @@ namespace GLTFast.Schema
         /// </summary>
         public int source = -1;
     }
+#endif
 }

--- a/Runtime/Scripts/Schema/TextureExtension.cs
+++ b/Runtime/Scripts/Schema/TextureExtension.cs
@@ -23,12 +23,13 @@ namespace GLTFast.Schema
     public class TextureExtension
     {
 
+        // ReSharper disable InconsistentNaming
         /// <inheritdoc cref="Extension.TextureBasisUniversal"/>
-        // ReSharper disable once InconsistentNaming
         public TextureBasisUniversal KHR_texture_basisu;
 
         /// <inheritdoc cref="Extension.TextureWebP"/>
-        public TextureBasisUniversal EXT_texture_webp;
+        public TextureWebP EXT_texture_webp;
+        // ReSharper enable InconsistentNaming
 
         internal void GltfSerialize(JsonWriter writer)
         {
@@ -47,6 +48,20 @@ namespace GLTFast.Schema
         /// <summary>
         /// Index of the image which defines a reference to the KTX v2 image
         /// with Basis Universal super-compression.
+        /// </summary>
+        public int source = -1;
+    }
+
+    /// <summary>
+    /// WebP texture extension
+    /// <seealso cref="Extension.TextureWebP"/>
+    /// </summary>
+    [System.Serializable]
+    public class TextureWebP
+    {
+
+        /// <summary>
+        /// Index of the image which defines a reference to the WebP image.
         /// </summary>
         public int source = -1;
     }

--- a/Runtime/Scripts/Schema/TextureExtension.cs
+++ b/Runtime/Scripts/Schema/TextureExtension.cs
@@ -27,6 +27,9 @@ namespace GLTFast.Schema
         // ReSharper disable once InconsistentNaming
         public TextureBasisUniversal KHR_texture_basisu;
 
+        /// <inheritdoc cref="Extension.TextureWebP"/>
+        public TextureBasisUniversal EXT_texture_webp;
+
         internal void GltfSerialize(JsonWriter writer)
         {
             throw new System.NotImplementedException($"GltfSerialize missing on {GetType()}");

--- a/Runtime/Scripts/glTFast.asmdef
+++ b/Runtime/Scripts/glTFast.asmdef
@@ -9,7 +9,8 @@
         "Ktx",
         "Unity.Meshopt.Decompress",
         "Unity.RenderPipelines.Universal.Runtime",
-        "Unity.RenderPipelines.HighDefinition.Runtime"
+        "Unity.RenderPipelines.HighDefinition.Runtime",
+        "unity.webp"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -93,6 +94,11 @@
             "name": "com.unity.shadergraph",
             "expression": "12",
             "define": "UNITY_SHADER_GRAPH_12_OR_NEWER"
+        },
+        {
+            "name": "com.netpyoung.webp",
+            "expression": "0.3.9",
+            "define": "WEBP"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
# WebP import support

## Features
- Allows _importing_ of WebP-encoded textures as defined in [EXT_texture_webp](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Vendor/EXT_texture_webp).
- Completely optional, only activated when dependencies are in place (using `WEBP` directives).

## Dependencies
- [Unity.WebP](https://github.com/netpyoung/unity.webp)
    - depends on [System.Runtime.CompilerServices.Unsafe](https://www.nuget.org/packages/System.Runtime.CompilerServices.Unsafe/)

## Tested
- Manually
  - Unity versions 2022.3.2f, 2021.3.27f, 2020.3.45f
  - In Editor and runtime (Windows x64 only)
  - In combination with and without KTX package to ensure compatibility
  - Using some internal and these [public test models](https://github.com/krisrok/gltf-test-models-webp)
- Automated tests of [glTFastTest](https://github.com/atteneder/glTFastTest/)
  - Using included projects glTFast-test-2022, -2021, -2020 (exact Unity versions see above)
  - Made sure test results are the same compared to [main](https://github.com/atteneder/glTFast/commit/5c36f4405012b13ad14ec871b77ba063c53cbbc3)
  - Skipped time consuming performance tests
  - (The whole test projects setup is a beast and I used it the best of my knowledge which might not be a lot)

## Discussion-worthy
- I tried to stay in line with existing workflows for integrating extensions, like with the [JsonUtility-workaround](https://github.com/atteneder/glTFast/pull/632/commits/ef70df82d50a397a10238a85ec782dd80d8ef907) using a fake schema to get rid of unset texture extension objects.
    - This way, importing a model can potentially be slower even if it does not contain any webp texture: We _have_ to check for empty, unset texture extensions objects. This is not really related to this extension, see [this commit message](https://github.com/atteneder/glTFast/pull/632/commits/8340c24ad72b467430e84d26dd13ace3a4bf3d33).
    - (All in all, glTFast could use a better JSON parser and/or a more sophisticated plugin/extension system but that is already discussed elsewhere :) )
- [KTX textures have higher priority than WebP](https://github.com/atteneder/glTFast/pull/632/commits/53c42428cc0307e689af9b74597532f5dbc581b4) _if a texture is present in both formats_. This was an arbitrary choice, as one has to come first.
- WebP decoding might stall the main thread (just like [loading PNG and JPG](https://github.com/atteneder/glTFast/issues/220) does), needs further testing.
