### PR TITLE
Fix NullReferenceException when export fails without a logger

### DIFF
--- a/Runtime/Scripts/Export/GltfWriter.cs
+++ b/Runtime/Scripts/Export/GltfWriter.cs
@@ -569,7 +569,7 @@ namespace GLTFast.Export
 
             if (m_Settings.Format != GltfFormat.Binary || GetFinalImageDestination() == ImageDestination.SeparateFile)
             {
-                m_Logger.Error(LogCode.None, "Save to Stream currently only works for self-contained glTF-Binary");
+                m_Logger?.Error(LogCode.None, "Save to Stream currently only works for self-contained glTF-Binary");
                 return false;
             }
 


### PR DESCRIPTION
Added missing null check