### PR TITLE
Decode large glTF-binary JSON chunks off the main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Main thread stall when loading glTF-binary files with large JSON chunks: the JSON string decode now runs on a background thread (gated by the defer agent, like the JSON parse), instead of always executing synchronously on the calling thread.
+
 ## [6.19.0] - 2026-05-19
 
 ### Added

--- a/Runtime/Scripts/GltfImport.cs
+++ b/Runtime/Scripts/GltfImport.cs
@@ -2075,11 +2075,38 @@ namespace GLTFast
                 {
                     Assert.IsNull(Root);
 
-                    Profiler.BeginSample("GetJSON");
                     var bytesStream = bytes.ToUnmanagedMemoryStream((uint)index, chLength);
                     var reader = new StreamReader(bytesStream);
-                    var json = await reader.ReadToEndAsync();
-                    Profiler.EndSample();
+                    string json = null;
+                    var predictedTime = chLength / (float)k_JsonParseSpeed;
+#if GLTFAST_THREADS && !MEASURE_TIMINGS
+                    if (DeferAgent.ShouldDefer(predictedTime))
+                    {
+                        // ReadToEndAsync completes synchronously on a memory stream
+                        // => decode in a thread.
+                        try
+                        {
+                            json = await Task.Run(() =>
+                            {
+                                Profiler.BeginSample("GetJSON");
+                                var result = reader.ReadToEnd();
+                                Profiler.EndSample();
+                                return result;
+                            }, cancellationToken);
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            cancellationToken.ThrowIfCancellationRequestedWithTracking();
+                        }
+                    }
+                    else
+#endif
+                    {
+                        // Chunk is small enough to decode within the frame budget.
+                        Profiler.BeginSample("GetJSON");
+                        json = await reader.ReadToEndAsync();
+                        Profiler.EndSample();
+                    }
 
                     var success = await ParseJsonAndLoadBuffers(json, cancellationToken);
 


### PR DESCRIPTION
I've been using this project to runtime decode some glbs with a lot of JSON data (lots of clips, animations etc). Without off-thread JSON string decode, each large glb causes a big stutter, which gets worse when reading many models in a short period. Large JSON chunks are typical for animation-heavy exports; the parse of the same string is already deferred off-thread, this just extends that to the decode feeding it. This solution has been both tested and benchmarked.

Let me know if you have any questions or if I misunderstood anything.

Edit: Possibly related to https://github.com/atteneder/glTFast/issues/750
Note: AI generated PR text from here on out. Review with caution. If it's garbage and there's a better way, just close it.

---

## Problem

`LoadGltfBinaryBuffer` reads a .glb's JSON chunk with `StreamReader.ReadToEndAsync()`. On an `UnmanagedMemoryStream` there is no I/O to await, so the call completes synchronously — the entire UTF-8 decode runs on the calling (main) thread, regardless of chunk size. The subsequent *parse* is already dispatched to a thread when the defer agent says it won't fit the frame budget; the *decode* wasn't.

## Fix

Gate the string decode through the same `DeferAgent.ShouldDefer(predictedTime)` verdict used by `ParseJsonAndLoadBuffers`, and run it via `Task.Run` when deferred. `k_JsonParseSpeed` over-estimates the decode cost, which errs toward deferring — a chunk whose parse gets deferred would never fit the budget with its decode included either. Platforms without `GLTFAST_THREADS` keep the original path.

No API or observable behavior change: the method already suspends for the off-thread parse, exceptions still surface at the same `await`, and the continuation resumes on the same synchronization context.

## Measurements

Unity 6000.5.3f1, macOS (Apple Silicon), Mono development player, Unity Profiler:

| JSON chunk | before (`GetJSON`, main thread) | after |
|---|---|---|
| 12.6 MB | ~104 ms stall | decode on worker; main-thread cost negligible |
| 8.2 MB | ~60–80 ms stall | same |

Chunks below the defer-agent threshold are unaffected (original inline path).

## Testing

- Existing behavior preserved for small chunks and non-threaded platforms (compiled-out branch).
- Verified in a project streaming several thousand .glb files: identical scene output, `GetJSON` samples moved to worker threads, main-thread frame spikes from this path eliminated.