### PR TITLE
Yield to the defer agent per mesh assignment during instantiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Frame budget overruns during scene instantiation of nodes with many mesh assignments: the hierarchy population now yields to the defer agent per mesh assignment, not only per node.
+
 ## [6.19.0] - 2026-05-19
 
 ### Added

--- a/Runtime/Scripts/GltfImport.cs
+++ b/Runtime/Scripts/GltfImport.cs
@@ -3003,10 +3003,10 @@ namespace GLTFast
                 }
             }
 
-            async Task IterateNodes(uint nodeIndex, uint? parentIndex, Action<uint, uint?> callback)
+            async Task IterateNodes(uint nodeIndex, uint? parentIndex, Func<uint, uint?, Task> callback)
             {
                 var node = this.Root.Nodes[(int)nodeIndex];
-                callback(nodeIndex, parentIndex);
+                await callback(nodeIndex, parentIndex);
                 await DeferAgent.BreakPoint();
                 if (node.children != null)
                 {
@@ -3045,10 +3045,8 @@ namespace GLTFast
                 Profiler.EndSample();
             }
 
-            void PopulateHierarchy(uint nodeIndex, uint? parentIndex)
+            async Task PopulateHierarchy(uint nodeIndex, uint? parentIndex)
             {
-
-                Profiler.BeginSample("PopulateHierarchy");
                 var node = this.Root.Nodes[(int)nodeIndex];
 
                 if (node.mesh >= 0)
@@ -3057,6 +3055,11 @@ namespace GLTFast
                     foreach (var meshAssignment in m_MeshAssignments.Values(node.mesh))
                     {
                         cancellationToken.ThrowIfCancellationRequestedWithTracking();
+                        // A node can carry many mesh assignments (one per primitive cluster of a
+                        // multi-material mesh). Populating all of them in one un-yielding callback
+                        // can far exceed the defer agent's frame budget
+                        // => yield per assignment, like the node iteration above does per node.
+                        Profiler.BeginSample("PopulateHierarchy");
 
                         var mesh = meshAssignment.mesh;
                         var meshName = string.IsNullOrEmpty(mesh.name) ? null : mesh.name;
@@ -3151,9 +3154,12 @@ namespace GLTFast
                         }
 
                         meshNumeration++;
+                        Profiler.EndSample();
+                        await DeferAgent.BreakPoint();
                     }
                 }
 
+                Profiler.BeginSample("PopulateHierarchy");
                 if (node.camera >= 0
                     && Root.Cameras != null
                     && node.camera < Root.Cameras.Count
@@ -3185,7 +3191,11 @@ namespace GLTFast
                 foreach (var nodeId in scene.nodes)
                 {
                     cancellationToken.ThrowIfCancellationRequestedWithTracking();
-                    await IterateNodes(nodeId, null, CreateHierarchy);
+                    await IterateNodes(nodeId, null, (index, parent) =>
+                    {
+                        CreateHierarchy(index, parent);
+                        return Task.CompletedTask;
+                    });
                 }
                 foreach (var nodeId in scene.nodes)
                 {


### PR DESCRIPTION
Same kind of performance related issue as https://github.com/atteneder/glTFast/pull/822 - if you have one very big object (say you are not the author and cannot easily split it), its instantiation can cause a stutter. Instantiation already yields to the frame budget per node, but a single node with many mesh assignments (multi-material meshes) populates them all in one go. This yields per assignment too, tunable by the existing frame budget logic.

Note: Everything below AI generated.

## Problem

`InstantiateSceneInternal` honors the defer agent's frame budget between nodes (`IterateNodes` awaits `BreakPoint()` per node), but `PopulateHierarchy` populates **all** of a node's mesh assignments in one un-yielding callback. A node with many assignments (any multi-material mesh; CAD/archviz-style content routinely has dozens per node) blows the frame budget with no way for the defer agent to intervene.

## Fix

Make the population callback `Task`-returning and yield `DeferAgent.BreakPoint()` after each mesh assignment — the same contract node iteration already follows, one level finer. The `PopulateHierarchy` profiler sample now wraps one assignment instead of a whole node, so captures attribute per assignment.

No public API change (the callback is a local function). Under `UninterruptedDeferAgent`, `BreakPoint()` is a no-op and behavior is byte-identical.

## Measurements

Unity 6000.5.3f1, macOS (Apple Silicon), Mono development player, streaming scenes with high-node-count glbs (up to ~40 primitive clusters per node):

| | before | after |
|---|---|---|
| worst `PopulateHierarchy` sample | 70.5 ms | 0.15 ms |
| worst instantiation-driven frame | 76-95 ms | within the defer agent's budget |

## Behavior notes for review

- Instantiation was already non-atomic under a budgeted defer agent (per-node yields); this makes the granularity finer, so a multi-material object can render some submeshes a frame or two before the rest. Same class of intermediate state as before, one level deeper.
- Cancellation can now land between a node's assignments; callers already own partial-scene teardown on cancel, so no new obligation.
- Assignment order, `meshNumeration`, and the `EndScene` timing (where skins/animations bind) are unchanged.