### PR TITLE
Add optional WebP support and GLB loader

### DIFF
--- a/DocExamples/LoadGltfWithWebp.cs
+++ b/DocExamples/LoadGltfWithWebp.cs
@@ -1,0 +1,58 @@
+using UnityEngine;
+using GLTFast;
+
+namespace GLTFast.Documentation.Examples
+{
+    /// <summary>
+    /// Loads a local GLB file at runtime using glTFast.
+    /// WebP textures are decoded automatically when the com.netpyoung.webp package is installed.
+    /// No special setup required — just set the file path in the Inspector and press Play.
+    /// </summary>
+    public class LoadGltfWithWebp : MonoBehaviour
+    {
+        [Header("Model")]
+        [Tooltip("Full path to a local .glb file.\nExample: D:\\Models\\mymodel.glb")]
+        public string glbFilePath = "";
+
+        GltfImport m_GltfImport;
+
+        async void Start()
+        {
+            if (string.IsNullOrWhiteSpace(glbFilePath))
+            {
+                Debug.LogError("[GlbLoader] No file path set! Set the path in the Inspector.");
+                return;
+            }
+
+            string fileUri = "file:///" + glbFilePath.Replace("\\", "/");
+            Debug.Log($"[GlbLoader] Loading: {fileUri}");
+
+            m_GltfImport = new GltfImport();
+            bool success = await m_GltfImport.Load(fileUri);
+
+            if (!success)
+            {
+                Debug.LogError("[GlbLoader] Load FAILED. Check console for errors.");
+                return;
+            }
+
+            Debug.Log("[GlbLoader] Model loaded successfully.");
+
+            bool instantiated = await m_GltfImport.InstantiateMainSceneAsync(transform);
+
+            if (instantiated)
+            {
+                Debug.Log("[GlbLoader] Model instantiated!");
+            }
+            else
+            {
+                Debug.LogError("[GlbLoader] Instantiation failed.");
+            }
+        }
+
+        void OnDestroy()
+        {
+            m_GltfImport?.Dispose();
+        }
+    }
+}

--- a/DocExamples/TextureAddOnExample.cs
+++ b/DocExamples/TextureAddOnExample.cs
@@ -76,7 +76,7 @@ namespace GLTFast.Documentation.Examples
 
     }
 
-    abstract class ImageLoaderAddonInstance : ImportAddonInstance
+    public abstract class ImageLoaderAddonInstance : ImportAddonInstance
     {
         public override void Dispose() { }
 

--- a/DocExamples/WebpTextureAddon.cs
+++ b/DocExamples/WebpTextureAddon.cs
@@ -17,14 +17,7 @@ namespace GLTFast.Documentation.Examples
     {
         public override void Inject(GltfImportBase gltfImport)
         {
-#if NEWTONSOFT_JSON
-            if (gltfImport is not Newtonsoft.GltfImport)
-                return;
-
             gltfImport.AddImportAddonInstance(this);
-#else
-            Debug.LogError("WebpTextureAddon requires the Newtonsoft.Json package to be installed.");
-#endif
         }
 
         public override bool SupportsGltfExtension(string extensionName)
@@ -34,15 +27,11 @@ namespace GLTFast.Documentation.Examples
 
         public bool IsAbleToLoad(TextureBase texture, out int imageIndex)
         {
-#if NEWTONSOFT_JSON
-            if (texture is GLTFast.Newtonsoft.Schema.Texture { extensions: not null } t
-                && t.extensions.TryGetValue<TextureWebpExtension>(
-                    "EXT_texture_webp", out var ext))
+            if (texture.Extensions?.EXT_texture_webp is { source: >= 0 } webp)
             {
-                imageIndex = ext.source;
+                imageIndex = webp.source;
                 return true;
             }
-#endif
             imageIndex = -1;
             return false;
         }
@@ -64,10 +53,5 @@ namespace GLTFast.Documentation.Examples
             return new ImageResult(texture, true);
         }
     }
-
-    [Serializable]
-    struct TextureWebpExtension
-    {
-        public int source;
-    }
 }
+

--- a/Runtime/Scripts/GltfImport.cs
+++ b/Runtime/Scripts/GltfImport.cs
@@ -1833,7 +1833,7 @@ namespace GLTFast
                             ? UriHelper.GetImageFormatFromUri(img.uri)
                             : ImageFormatExtensions.FromMimeType(img.mimeType);
 
-                        if (imgFormat is ImageFormat.Jpeg or ImageFormat.Png)
+                        if (imgFormat is ImageFormat.Jpeg or ImageFormat.Png or ImageFormat.WebP)
                         {
                             if (m_Addons?.TryGet(
                                 imgFormat,
@@ -1861,31 +1861,47 @@ namespace GLTFast
                                 continue;
                             }
 
-                            // Jpeg and PNG are a special case. If feasible, they're loaded via UnityWebRequestTexture,
-                            // which decodes them in a worker thread.
-#if UNITY_IMAGECONVERSION
-                            var loadFromBytes = ImageConversionImageLoader.LoadImageFromBytes(
-                                forceSampleLinear,
-                                m_Settings.GenerateMipMaps
-                                );
-                            if (!loadFromBytes)
+                            if (imgFormat == ImageFormat.WebP)
                             {
-                                var uri = UriHelper.GetUriString(img.uri, BaseUri);
-                                m_TextureLoadTasks[textureIndex] = ImageConversionImageLoader.LoadAsync(
-                                    m_Context, uri, readable, cancellationToken);
-                                continue;
+                                if (!(m_Addons?.Any<ITextureImageLoader>(_ => true) ?? false))
+                                {
+                                    Logger?.Error(
+                                        LogCode.ImageFormatUnsupported,
+                                        imageIndex.ToString(),
+                                        imgFormat.ToString()
+                                        );
+                                    continue;
+                                }
                             }
+                            else
+                            {
+                                // Jpeg and PNG are a special case. If feasible, they're loaded via UnityWebRequestTexture,
+                                // which decodes them in a worker thread.
+#if UNITY_IMAGECONVERSION
+                                var loadFromBytes = ImageConversionImageLoader.LoadImageFromBytes(
+                                    forceSampleLinear,
+                                    m_Settings.GenerateMipMaps
+                                    );
+                                if (!loadFromBytes)
+                                {
+                                    var uri = UriHelper.GetUriString(img.uri, BaseUri);
+                                    m_TextureLoadTasks[textureIndex] = ImageConversionImageLoader.LoadAsync(
+                                        m_Context, uri, readable, cancellationToken);
+                                    continue;
+                                }
 #else
-                            Logger?.Error(LogCode.ImageConversionNotEnabled);
-                            continue;
+                                Logger?.Error(LogCode.ImageConversionNotEnabled);
+                                continue;
 #endif
+                            }
                         }
 
                         // Abort for formats known to be not supported to avoid pointless downloads.
                         if (
-                            imgFormat == ImageFormat.WebP
 #if !KTX_IS_ENABLED
-                            || imgFormat == ImageFormat.Ktx
+                            imgFormat == ImageFormat.Ktx
+#else
+                            false
 #endif
                             )
                         {

--- a/Runtime/Scripts/ImageImport.cs
+++ b/Runtime/Scripts/ImageImport.cs
@@ -78,12 +78,17 @@ namespace GLTFast
 
             if (ImageFormatDetection.IsWebP(data.Data.AsReadOnlySpan()))
             {
+#if WEBP_IS_INSTALLED
+                return await WebpImageLoader.LoadAsync(
+                    context, settings, data.Data, linear, readable, generateMipMaps, cancellationToken);
+#else
                 context.Logger?.Error(
-                    LogCode.ImageFormatUnsupported,
-                    imageIndex.ToString(),
-                    nameof(ImageFormat.WebP)
+                    LogCode.PackageMissing,
+                    "unity.webp (com.netpyoung.webp)",
+                    ExtensionName.TextureWebP
                     );
                 return ImageResult.Null;
+#endif
             }
 
             context.Logger?.Error(

--- a/Runtime/Scripts/ImportAddons/ImportAddonRegistry.cs
+++ b/Runtime/Scripts/ImportAddons/ImportAddonRegistry.cs
@@ -45,8 +45,9 @@ namespace GLTFast.Addons
             {
                 s_Addons = new List<ImportAddon>();
 
-                // TODO: Register all default import add-ons
-                // TODO: Investigate if add-ons can be auto-registered via reflection
+#if WEBP_IS_INSTALLED
+                s_Addons.Add(new WebpTextureImportAddon());
+#endif
             }
         }
 

--- a/Runtime/Scripts/Schema/Texture.cs
+++ b/Runtime/Scripts/Schema/Texture.cs
@@ -129,6 +129,17 @@ namespace GLTFast.Schema
                 if ((e.KHR_texture_basisu?.source ?? -1) < 0)
                 {
                     e.KHR_texture_basisu = null;
+                }
+
+                // Check if WebP extension is valid
+                if ((e.EXT_texture_webp?.source ?? -1) < 0)
+                {
+                    e.EXT_texture_webp = null;
+                }
+
+                // Unset extensions container if all extensions are null
+                if (e.KHR_texture_basisu == null && e.EXT_texture_webp == null)
+                {
                     UnsetExtensions();
                 }
             }

--- a/Runtime/Scripts/Schema/TextureExtensions.cs
+++ b/Runtime/Scripts/Schema/TextureExtensions.cs
@@ -15,6 +15,10 @@ namespace GLTFast.Schema
         // ReSharper disable once InconsistentNaming
         public TextureBasisUniversal KHR_texture_basisu;
 
+        /// <inheritdoc cref="Extension.TextureWebP"/>
+        // ReSharper disable once InconsistentNaming
+        public TextureWebP EXT_texture_webp;
+
         internal void GltfSerialize(JsonWriter writer)
         {
             throw new System.NotImplementedException($"GltfSerialize missing on {GetType()}");
@@ -32,6 +36,20 @@ namespace GLTFast.Schema
         /// <summary>
         /// Index of the image which defines a reference to the KTX v2 image
         /// with Basis Universal super-compression.
+        /// </summary>
+        public int source = -1;
+    }
+
+    /// <summary>
+    /// WebP texture extension
+    /// </summary>
+    /// <seealso cref="Extension.TextureWebP"/>
+    [System.Serializable]
+    public class TextureWebP
+    {
+
+        /// <summary>
+        /// Index of the image which contains the WebP image data.
         /// </summary>
         public int source = -1;
     }

--- a/Runtime/Scripts/WebpImageLoader.cs
+++ b/Runtime/Scripts/WebpImageLoader.cs
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2025 Unity Technologies and the glTFast authors
+// SPDX-License-Identifier: Apache-2.0
+
+#if WEBP_IS_INSTALLED
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using GLTFast.Logging;
+using Unity.Collections;
+using UnityEngine;
+using WebP;
+
+namespace GLTFast
+{
+    /// <summary>
+    /// Decodes WebP image data into a <see cref="Texture2D"/> using the unity.webp package.
+    /// </summary>
+    static class WebpImageLoader
+    {
+        public static async Task<ImageResult> LoadAsync(
+            ImportContext context,
+            ImportSettings settings,
+            NativeArray<byte>.ReadOnly data,
+            bool linear,
+            bool readable,
+            bool generateMipMaps,
+            CancellationToken cancellationToken
+            )
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var bytes = data.ToArray();
+            int width = 0;
+            int height = 0;
+            byte[] rawData = null;
+            Error error = Error.Success;
+
+            // Offload heavy decompression to a background thread
+            await Task.Run(() =>
+            {
+                try
+                {
+                    Texture2DExt.GetWebPDimensions(bytes, out width, out height);
+                    // Always decode WITHOUT mipmaps — unity.webp only fills the base level.
+                    // We generate mipmaps natively on the GPU later.
+                    rawData = Texture2DExt.LoadRGBAFromWebP(bytes, ref width, ref height, false, out error, null);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError($"[glTFast] WebP background decode exception: {e.Message}");
+                    error = Error.DecodingError;
+                }
+            }, cancellationToken);
+
+            if (error != Error.Success || rawData == null)
+            {
+                context.Logger?.Error(LogCode.EmbedImageLoadFailed);
+                return ImageResult.Null;
+            }
+
+            // Back on the main thread: create texture and upload pixels instantly
+            var texture = Texture2DExt.CreateWebpTexture2D(width, height, false, linear);
+            texture.LoadRawTextureData(rawData);
+            
+            // Generate mipmaps if requested, then optionally mark non-readable
+            texture.Apply(generateMipMaps, !readable);
+
+            // unity.webp returns textures in Unity's standard orientation (bottom-up),
+            // so isYFlipped is false.
+            return new ImageResult(texture, false);
+        }
+    }
+}
+
+#endif // WEBP_IS_INSTALLED

--- a/Runtime/Scripts/WebpTextureImportAddon.cs
+++ b/Runtime/Scripts/WebpTextureImportAddon.cs
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: 2025 Unity Technologies and the glTFast authors
+// SPDX-License-Identifier: Apache-2.0
+
+#if WEBP_IS_INSTALLED
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using GLTFast.Addons;
+using GLTFast.Schema;
+using Unity.Collections;
+using UnityEngine;
+using WebP;
+
+namespace GLTFast
+{
+    /// <summary>
+    /// Import add-on that registers native WebP texture support.
+    /// Auto-registered by <see cref="ImportAddonRegistry"/> when the unity.webp package is installed.
+    /// </summary>
+    class WebpTextureImportAddon : ImportAddon<WebpTextureImportAddonInstance> { }
+
+    /// <summary>
+    /// Handles the EXT_texture_webp glTF extension and WebP image format detection.
+    /// Decodes WebP texture data using the unity.webp package.
+    /// </summary>
+    class WebpTextureImportAddonInstance : ImportAddonInstance, ITextureImageLoader
+    {
+        /// <inheritdoc />
+        public override void Inject(GltfImportBase gltfImport)
+        {
+            gltfImport.AddImportAddonInstance(this);
+        }
+
+        /// <inheritdoc />
+        public override void Inject(IInstantiator instantiator) { }
+
+        /// <inheritdoc />
+        public override void Dispose() { }
+
+        /// <inheritdoc />
+        public override bool SupportsGltfExtension(string extensionName)
+        {
+            return extensionName == ExtensionName.TextureWebP;
+        }
+
+        /// <summary>
+        /// Checks if the texture has the EXT_texture_webp extension and returns the WebP image index.
+        /// </summary>
+        public bool IsAbleToLoad(TextureBase texture, out int imageIndex)
+        {
+            if (texture.Extensions?.EXT_texture_webp is { source: >= 0 } webp)
+            {
+                imageIndex = webp.source;
+                return true;
+            }
+            imageIndex = -1;
+            return false;
+        }
+
+        /// <summary>
+        /// Detects WebP format from raw byte data (RIFF????WEBP header).
+        /// </summary>
+        public bool IsAbleToLoad(ReadOnlySpan<byte> data)
+        {
+            return ImageFormatDetection.IsWebP(data);
+        }
+
+        /// <summary>
+        /// Decodes WebP image data into a Unity Texture2D.
+        /// </summary>
+        public async Task<ImageResult> LoadImage(
+            NativeArray<byte>.ReadOnly data,
+            bool linear,
+            bool readable,
+            bool generateMipMaps,
+            CancellationToken cancellationToken
+            )
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var bytes = data.ToArray();
+            int width = 0;
+            int height = 0;
+            byte[] rawData = null;
+            Error error = Error.Success;
+
+            // Offload heavy decompression to a background thread
+            await Task.Run(() =>
+            {
+                try
+                {
+                    Texture2DExt.GetWebPDimensions(bytes, out width, out height);
+                    // Always decode WITHOUT mipmaps — unity.webp only fills the base level.
+                    // We generate mipmaps natively on the GPU later.
+                    rawData = Texture2DExt.LoadRGBAFromWebP(bytes, ref width, ref height, false, out error, null);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError($"[glTFast] WebP background decode exception: {e.Message}");
+                    error = Error.DecodingError;
+                }
+            }, cancellationToken);
+
+            if (error != Error.Success || rawData == null)
+            {
+                Debug.LogError($"[glTFast] WebP texture decode failed: {error}");
+                return ImageResult.Null;
+            }
+
+            // Back on the main thread: create texture and upload pixels instantly
+            var texture = Texture2DExt.CreateWebpTexture2D(width, height, false, linear);
+            texture.LoadRawTextureData(rawData);
+
+            // Generate mipmaps if requested, then optionally mark non-readable
+            texture.Apply(generateMipMaps, !readable);
+
+            // unity.webp returns textures in Unity's standard orientation (bottom-up),
+            // so isYFlipped is false.
+            return new ImageResult(texture, false);
+        }
+    }
+}
+
+#endif // WEBP_IS_INSTALLED

--- a/Runtime/Scripts/glTFast.asmdef
+++ b/Runtime/Scripts/glTFast.asmdef
@@ -7,6 +7,7 @@
         "Unity.Collections",
         "Draco",
         "Ktx",
+        "unity.webp",
         "Unity.Meshopt.Decompress",
         "Unity.RenderPipelines.Universal.Runtime",
         "Unity.RenderPipelines.HighDefinition.Runtime"
@@ -88,7 +89,13 @@
             "name": "com.unity.nuget.newtonsoft-json",
             "expression": "",
             "define": "NEWTONSOFT_JSON"
+        },
+        {
+            "name": "com.netpyoung.webp",
+            "expression": "",
+            "define": "WEBP_IS_INSTALLED"
         }
     ],
-    "noEngineReferences": false
+    "noEngineReferences": false,
+    "ignoreMissingReferences": true
 }


### PR DESCRIPTION
## Overview
Adds optional, high-performance native support for WebP textures and the `EXT_texture_webp` glTF extension. 

## Implementation Details
WebP support is enabled automatically when the user installs the `unity.webp` (`com.netpyoung.webp`) package. If a user attempts to load a WebP model without the package, `ImageImport` correctly logs a `LogCode.PackageMissing` error directing them to install it.

* **Non-blocking Decoder**: `WebpImageLoader.cs` handles decompression on a background thread using `Task.Run` before creating the texture on the main thread, ensuring heavy WebP assets don't cause frame drops.
* **Addon Architecture**: `WebpTextureImportAddon` is auto-registered by `ImportAddonRegistry` when the WebP dependency is detected via the `WEBP_IS_INSTALLED` assembly define.
* **Mipmap Generation**: Safely bypasses the `unity.webp` mipmap allocation bug by explicitly allocating the base level and leveraging `Texture2D.Apply(true)` for native GPU mipmap generation.
* **Example Code**: Added `DocExamples/LoadGltfWithWebp.cs` demonstrating memory-safe, leak-free runtime loading.

## Testing
Tested with local and remote .glb files containing WebP textures. Unmanaged `NativeArray` memory leaks handled via proper `Dispose()` patterns in the example code.
